### PR TITLE
Implement per-phase tool filtering with call history tracking

### DIFF
--- a/middleware/format/formatter.go
+++ b/middleware/format/formatter.go
@@ -29,7 +29,23 @@ type ToolFormatter interface {
 type ToolCall struct {
 	Name      string
 	Arguments map[string]interface{}
-	ID        string
+}
+
+type flexibleArgs map[string]interface{}
+
+func (fa *flexibleArgs) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		*fa = make(map[string]interface{})
+		return nil
+	}
+	if data[0] == '"' {
+		var argsStr string
+		if err := json.Unmarshal(data, &argsStr); err != nil {
+			return err
+		}
+		return json.Unmarshal([]byte(argsStr), (*map[string]interface{})(fa))
+	}
+	return json.Unmarshal(data, (*map[string]interface{})(fa))
 }
 
 type ToolCallParser func(response string) ([]ToolCall, error)
@@ -110,19 +126,17 @@ func ParseOpenAIToolCalls(response string) ([]ToolCall, error) {
 	var calls []ToolCall
 	var toolCalls []struct {
 		Function struct {
-			Name      string          `json:"name"`
-			Arguments json.RawMessage `json:"arguments"`
+			Name      string       `json:"name"`
+			Arguments flexibleArgs `json:"arguments"`
 		} `json:"function"`
 	}
 	if err := json.Unmarshal([]byte(response), &toolCalls); err != nil {
 		return nil, err
 	}
 	for _, tc := range toolCalls {
-		args := make(map[string]interface{})
-		json.Unmarshal(tc.Function.Arguments, &args)
 		calls = append(calls, ToolCall{
 			Name:      tc.Function.Name,
-			Arguments: args,
+			Arguments: tc.Function.Arguments,
 		})
 	}
 	return calls, nil

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,6 +3,8 @@ package middleware
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync"
 
 	"github.com/pedro/agent-middleware/types"
 )
@@ -10,12 +12,95 @@ import (
 var ErrToolNotFound = errors.New("tool not found")
 var ErrPolicyDenied = errors.New("policy denied")
 
+type CallHistory struct {
+	CalledTools map[string]bool
+	FailedTools map[string]int
+	mu          sync.RWMutex
+}
+
+func NewCallHistory() *CallHistory {
+	return &CallHistory{
+		CalledTools: make(map[string]bool),
+		FailedTools: make(map[string]int),
+	}
+}
+
+func (ch *CallHistory) RecordToolCall(toolName string, success bool) {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	if success {
+		ch.CalledTools[toolName] = true
+		delete(ch.FailedTools, toolName)
+	} else {
+		ch.FailedTools[toolName]++
+	}
+}
+
+func (ch *CallHistory) GetCalledTools() map[string]bool {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	result := make(map[string]bool)
+	for k, v := range ch.CalledTools {
+		result[k] = v
+	}
+	return result
+}
+
+func (ch *CallHistory) GetFailedTools() map[string]int {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	result := make(map[string]int)
+	for k, v := range ch.FailedTools {
+		result[k] = v
+	}
+	return result
+}
+
+func (ch *CallHistory) Reset() {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	ch.CalledTools = make(map[string]bool)
+	ch.FailedTools = make(map[string]int)
+}
+
+func (ch *CallHistory) ResetPhase(phase string) {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	for tool := range ch.CalledTools {
+		if phase == "" || strings.HasPrefix(tool, phase+":") {
+			delete(ch.CalledTools, tool)
+		}
+	}
+}
+
+const MaxFailures = 3
+
+func (ch *CallHistory) HasToolFailedTooManyTimes(toolName string) bool {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	return ch.FailedTools[toolName] >= MaxFailures
+}
+
+func (ch *CallHistory) WasToolCalled(toolName string) bool {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	return ch.CalledTools[toolName]
+}
+
 type Middleware struct {
-	executor types.ToolExecutor
-	auditor  Auditor
-	policy   PolicyEvaluator
-	tools    []types.ToolDefinition
-	toolMap  map[string]types.ToolDefinition
+	executor    types.ToolExecutor
+	auditor     Auditor
+	policy      PolicyEvaluator
+	tools       []types.ToolDefinition
+	toolMap     map[string]types.ToolDefinition
+	callHistory *CallHistory
 }
 
 type MiddlewareOption func(*Middleware)
@@ -35,11 +120,12 @@ func WithPolicyEvaluator(policy PolicyEvaluator) MiddlewareOption {
 func New(executor ToolExecutor, policy Policy, opts ...MiddlewareOption) *Middleware {
 	evaluator := NewPolicyEvaluator(policy)
 	mw := &Middleware{
-		executor: executor,
-		auditor:  NoOpAuditor{},
-		policy:   evaluator,
-		tools:    executor.ListTools(),
-		toolMap:  make(map[string]ToolDefinition),
+		executor:    executor,
+		auditor:     NoOpAuditor{},
+		policy:      evaluator,
+		tools:       executor.ListTools(),
+		toolMap:     make(map[string]ToolDefinition),
+		callHistory: NewCallHistory(),
 	}
 
 	for _, tool := range mw.tools {
@@ -84,6 +170,17 @@ func (m *Middleware) CallTool(ctx context.Context, name string, args map[string]
 
 	result, err := m.executor.CallTool(ctx, name, args)
 
+	success := err == nil
+	if result != nil && result.Error != nil {
+		success = false
+	}
+
+	toolKey := name
+	if callerCtx.Phase != "" {
+		toolKey = callerCtx.Phase + ":" + name
+	}
+	m.callHistory.RecordToolCall(toolKey, success)
+
 	if result == nil {
 		result = &ToolResult{Error: err}
 	}
@@ -99,9 +196,15 @@ func (m *Middleware) CallTool(ctx context.Context, name string, args map[string]
 
 func (m *Middleware) ListTools() []ToolDefinition {
 	if m.policy == nil {
-		return m.tools
+		return m.filterFailedTools(m.tools, "")
 	}
-	return m.policy.FilterToolList(m.tools)
+	tools := m.policy.FilterToolList(m.tools)
+	return m.filterFailedTools(tools, "")
+}
+
+func (m *Middleware) GetToolsWithContext(ctx context.Context) []ToolDefinition {
+	callerCtx := extractCallerContext(ctx)
+	return m.GetToolsForPhase("", callerCtx)
 }
 
 func (m *Middleware) GetAuditor() Auditor {
@@ -110,6 +213,70 @@ func (m *Middleware) GetAuditor() Auditor {
 
 func (m *Middleware) GetPolicy() PolicyEvaluator {
 	return m.policy
+}
+
+func (m *Middleware) GetCallHistory() *CallHistory {
+	return m.callHistory
+}
+
+// GetToolsForPhase returns the list of tools available for a given phase.
+// A "phase" represents a stage in a multi-phase agent workflow (from PedroCLI's
+// phased executor). Each phase can have different tools available.
+// This method filters tools to exclude:
+//   - Tools already called in this phase (prevents loops)
+//   - Tools that have failed 3+ times in this phase (gives up after repeated failures)
+//
+// The phase is either passed directly as the phase argument or extracted from
+// callerCtx.Phase. Tools are tracked with keys like "phaseName:toolName" to
+// maintain per-phase call history.
+func (m *Middleware) GetToolsForPhase(phase string, callerCtx CallerContext) []ToolDefinition {
+	if m.policy == nil {
+		return m.tools
+	}
+
+	tools := m.policy.FilterToolList(m.tools)
+
+	if phase == "" && callerCtx.Phase == "" {
+		return tools
+	}
+
+	activePhase := phase
+	if activePhase == "" {
+		activePhase = callerCtx.Phase
+	}
+
+	if activePhase == "" {
+		return tools
+	}
+
+	var filtered []ToolDefinition
+	for _, tool := range tools {
+		key := activePhase + ":" + tool.Name
+		if m.callHistory.WasToolCalled(key) {
+			continue
+		}
+		if m.callHistory.HasToolFailedTooManyTimes(tool.Name) {
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+
+	return filtered
+}
+
+func (m *Middleware) filterFailedTools(tools []ToolDefinition, phase string) []ToolDefinition {
+	var filtered []ToolDefinition
+	for _, tool := range tools {
+		checkKey := tool.Name
+		if phase != "" {
+			checkKey = phase + ":" + tool.Name
+		}
+		if m.callHistory.HasToolFailedTooManyTimes(checkKey) {
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+	return filtered
 }
 
 func extractCallerContext(ctx context.Context) CallerContext {

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -229,3 +229,186 @@ func TestMergeMetadata(t *testing.T) {
 		t.Error("b not added to nil map")
 	}
 }
+
+func TestCallHistory_RecordToolCall(t *testing.T) {
+	ch := NewCallHistory()
+
+	ch.RecordToolCall("tool1", true)
+	if !ch.WasToolCalled("tool1") {
+		t.Error("tool1 should be marked as called")
+	}
+
+	ch.RecordToolCall("tool2", false)
+	if ch.WasToolCalled("tool2") {
+		t.Error("tool2 should not be marked as called on failure")
+	}
+
+	failed := ch.GetFailedTools()
+	if failed["tool2"] != 1 {
+		t.Errorf("expected tool2 failure count 1, got %d", failed["tool2"])
+	}
+}
+
+func TestCallHistory_FailureTracking(t *testing.T) {
+	ch := NewCallHistory()
+
+	ch.RecordToolCall("tool1", false)
+	ch.RecordToolCall("tool1", false)
+	ch.RecordToolCall("tool1", false)
+
+	if !ch.HasToolFailedTooManyTimes("tool1") {
+		t.Error("tool1 should be marked as failed too many times after 3 failures")
+	}
+
+	ch.RecordToolCall("tool1", true)
+	if ch.HasToolFailedTooManyTimes("tool1") {
+		t.Error("tool1 should be cleared after success")
+	}
+}
+
+func TestCallHistory_Reset(t *testing.T) {
+	ch := NewCallHistory()
+
+	ch.RecordToolCall("tool1", true)
+	ch.RecordToolCall("tool2", false)
+
+	ch.Reset()
+
+	if ch.WasToolCalled("tool1") {
+		t.Error("tool1 should be cleared after reset")
+	}
+	if ch.GetFailedTools()["tool2"] != 0 {
+		t.Error("tool2 failures should be cleared after reset")
+	}
+}
+
+func TestMiddleware_CallHistory_RecordsSuccess(t *testing.T) {
+	executor := newMockExecutor([]string{"tool1"})
+	policy := Policy{
+		Rules: []Rule{{Name: "allow-tool1", Tools: []string{"tool1"}, Action: ActionAllow}},
+	}
+
+	mw := New(executor, policy)
+	_, _ = mw.CallTool(context.Background(), "tool1", nil)
+
+	history := mw.GetCallHistory()
+	if !history.WasToolCalled("tool1") {
+		t.Error("tool1 should be recorded as called")
+	}
+}
+
+func TestMiddleware_CallHistory_RecordsFailure(t *testing.T) {
+	executor := newMockExecutor([]string{"tool1"})
+	executor.failTool = "tool1"
+	policy := Policy{
+		Rules: []Rule{{Name: "allow-tool1", Tools: []string{"tool1"}, Action: ActionAllow}},
+	}
+
+	mw := New(executor, policy)
+	_, _ = mw.CallTool(context.Background(), "tool1", nil)
+
+	history := mw.GetCallHistory()
+	failed := history.GetFailedTools()
+	if failed["tool1"] != 1 {
+		t.Errorf("expected tool1 failure count 1, got %d", failed["tool1"])
+	}
+}
+
+func TestMiddleware_CallHistory_BlocksAfter3Failures(t *testing.T) {
+	executor := newMockExecutor([]string{"tool1"})
+	executor.failTool = "tool1"
+	policy := Policy{
+		Rules: []Rule{{Name: "allow-tool1", Tools: []string{"tool1"}, Action: ActionAllow}},
+	}
+
+	mw := New(executor, policy)
+
+	for i := 0; i < 3; i++ {
+		_, _ = mw.CallTool(context.Background(), "tool1", nil)
+	}
+
+	tools := mw.ListTools()
+	found := false
+	for _, t := range tools {
+		if t.Name == "tool1" {
+			found = true
+			break
+		}
+	}
+	if found {
+		t.Error("tool1 should be filtered out after 3 failures")
+	}
+}
+
+func TestMiddleware_GetCallHistory(t *testing.T) {
+	executor := newMockExecutor([]string{"tool1"})
+	policy := Policy{
+		Rules: []Rule{{Name: "allow-all", Tools: []string{"*"}, Action: ActionAllow}},
+	}
+
+	mw := New(executor, policy)
+	history := mw.GetCallHistory()
+
+	if history == nil {
+		t.Error("GetCallHistory returned nil")
+	}
+}
+
+func TestMiddleware_GetToolsWithContext_NoPhase(t *testing.T) {
+	executor := newMockExecutor([]string{"tool1", "tool2"})
+	policy := Policy{
+		Rules: []Rule{{Name: "allow-all", Tools: []string{"*"}, Action: ActionAllow}},
+	}
+
+	mw := New(executor, policy)
+	tools := mw.GetToolsWithContext(context.Background())
+
+	if len(tools) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(tools))
+	}
+}
+
+func TestMiddleware_GetToolsForPhase_TracksPerPhase(t *testing.T) {
+	executor := newMockExecutor([]string{"tool1"})
+	policy := Policy{
+		Rules: []Rule{{Name: "allow-all", Tools: []string{"*"}, Action: ActionAllow}},
+	}
+
+	mw := New(executor, policy)
+
+	tools := mw.GetToolsForPhase("phase1", CallerContext{})
+	if len(tools) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(tools))
+	}
+
+	_, _ = mw.CallTool(WithCallerContext(context.Background(), CallerContext{Phase: "phase1"}), "tool1", nil)
+
+	tools = mw.GetToolsForPhase("phase1", CallerContext{})
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools after calling, got %d", len(tools))
+	}
+
+	tools = mw.GetToolsForPhase("phase2", CallerContext{})
+	if len(tools) != 1 {
+		t.Errorf("expected 1 tool in phase2 (different phase), got %d", len(tools))
+	}
+}
+
+func TestMiddleware_GetToolsForPhase_FiltersFailed(t *testing.T) {
+	executor := newMockExecutor([]string{"tool1", "tool2"})
+	executor.failTool = "tool2"
+	policy := Policy{
+		Rules: []Rule{{Name: "allow-all", Tools: []string{"*"}, Action: ActionAllow}},
+	}
+
+	mw := New(executor, policy)
+
+	_, _ = mw.CallTool(context.Background(), "tool2", nil)
+	_, _ = mw.CallTool(context.Background(), "tool2", nil)
+	_, _ = mw.CallTool(context.Background(), "tool2", nil)
+
+	tools := mw.GetToolsForPhase("phase1", CallerContext{})
+	if len(tools) != 1 {
+		t.Errorf("expected 1 tool (tool1), got %d", len(tools))
+	}
+}

--- a/middleware/types/types.go
+++ b/middleware/types/types.go
@@ -33,6 +33,7 @@ type CallerContext struct {
 	UserID    string
 	SessionID string
 	Source    string
+	Phase     string
 	Metadata  map[string]interface{}
 }
 


### PR DESCRIPTION
## Summary
- Add CallHistory struct to track called tools and failures per phase
- Add Phase field to CallerContext for phase-aware filtering
- Implement GetToolsForPhase to filter tools based on phase and call history
- Add failure tracking with configurable max failures per tool
- Add comprehensive tests for call history and phase-based filtering