### PR TITLE
Update Go CI workflow

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -20,17 +20,22 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: "1.26.1"
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
+      - name: Restore Go cache
+        uses: actions/cache/restore@v4
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: nonexistent
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-${{ hashFiles('go.mod') }}-
+
+      - name: Download Go modules
+        run: cd middleware && go mod download
 
       - name: Run tests
         run: cd middleware && go test -v ./...
@@ -51,11 +56,14 @@ jobs:
       - name: Build
         run: cd middleware && go build ./...
 
-      - name: Run golint
-        uses: golangci/golangci-lint-action@v9.2.0
+      - name: golangci-lint
+        env:
+          CGO_ENABLED: 1
+        uses: golangci/golangci-lint-action@v9
         with:
+          version: v2.11
+          skip-cache: true
           working-directory: ./middleware
-          args: --timeout=5m
 
       - name: Vet
         run: cd middleware && go vet ./...


### PR DESCRIPTION
## Summary
- Update setup-go to v6 with go-version 1.26.1
- Use cache/restore v4 pattern with proper key and restore-keys
- Add explicit go mod download step
- Update golangci-lint-action to v9 with v2.11 and skip-cache