### PR TITLE
Add eval harness for tool calling regression testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 __pycache__/
 *.pyc
 *.pyo
+**/__pycache__/
+testing/evals/output/

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ help:
 	@echo "  --base-url         - Override base URL via CLI"
 
 evals:
-	python3 -m testing.evals.main --all --models gpt-oss-20b,qwen3-coder-30b
+	python3 -m testing.evals.main --all --models nemotron-3-super-120b
 
 evals-file-search:
-	python3 -m testing.evals.main --file-search --models gpt-oss-20b,qwen3-coder-30b
+	python3 -m testing.evals.main --file-search --models nemotron-3-super-120b
 
 evals-general:
-	python3 -m testing.evals.main --general --models gpt-oss-20b,qwen3-coder-30b
+	python3 -m testing.evals.main --general --models nemotron-3-super-120b
 
 evals-clean:
 	rm -rf testing/evals/output/*.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: help evals evals-file-search evals-general evals-clean
+
+help:
+	@echo "Available targets:"
+	@echo "  evals              - Run all evals (file search + general) sequentially against models"
+	@echo "  evals-file-search  - Run only file search tool call evals"
+	@echo "  evals-general      - Run only general tool calling evals"
+	@echo "  evals-clean        - Clean eval output files"
+	@echo ""
+	@echo "Environment variables / args:"
+	@echo "  EVAL_BASE_URL      - API base URL (default: http://pedrogpt:8080/v1)"
+	@echo "  EVAL_MODELS        - Comma-separated model list (default: gpt-oss,nemotron,qwen)"
+	@echo "  --models           - Override models via CLI"
+	@echo "  --base-url         - Override base URL via CLI"
+
+evals:
+	python3 -m testing.evals.main --all --models gpt-oss-20b,qwen3-coder-30b
+
+evals-file-search:
+	python3 -m testing.evals.main --file-search --models gpt-oss-20b,qwen3-coder-30b
+
+evals-general:
+	python3 -m testing.evals.main --general --models gpt-oss-20b,qwen3-coder-30b
+
+evals-clean:
+	rm -rf testing/evals/output/*.json
+	@echo "Cleaned eval output files"

--- a/testing/evals/__init__.py
+++ b/testing/evals/__init__.py
@@ -1,0 +1,1 @@
+# Eval Harness for Tool Calling Testing

--- a/testing/evals/cases/__init__.py
+++ b/testing/evals/cases/__init__.py
@@ -1,0 +1,4 @@
+from testing.evals.cases.file_search import FILE_SEARCH_CASES
+from testing.evals.cases.general import GENERAL_CASES
+
+__all__ = ["FILE_SEARCH_CASES", "GENERAL_CASES"]

--- a/testing/evals/cases/file_search.py
+++ b/testing/evals/cases/file_search.py
@@ -1,0 +1,86 @@
+"""
+File search tool call test cases.
+"""
+from testing.evals.runner import EvalCase
+
+FILE_SEARCH_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "glob",
+            "description": "Find files matching a glob pattern in a directory",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Glob pattern to match files"},
+                    "directory": {"type": "string", "description": "Directory to search in"}
+                },
+                "required": ["pattern"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read contents of a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "Path to the file to read"}
+                },
+                "required": ["path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "search_files",
+            "description": "Search for text content in files",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Text to search for"},
+                    "path": {"type": "string", "description": "Directory path to search in"}
+                },
+                "required": ["query"]
+            }
+        }
+    }
+]
+
+FILE_SEARCH_CASES = [
+    EvalCase(
+        name="glob_python_files",
+        description="Find all Python files in the current directory",
+        system_prompt="You are a helpful assistant with file system access. Use the provided tools to help the user.",
+        user_message="Find all Python files in the current directory",
+        tools=FILE_SEARCH_TOOLS,
+        expected_tool="glob"
+    ),
+    EvalCase(
+        name="glob_md_files",
+        description="Find all Markdown files",
+        system_prompt="You are a helpful assistant with file system access. Use the provided tools to help the user.",
+        user_message="List all markdown files (*.md) in this directory",
+        tools=FILE_SEARCH_TOOLS,
+        expected_tool="glob"
+    ),
+    EvalCase(
+        name="search_code",
+        description="Search for specific code pattern",
+        system_prompt="You are a helpful assistant with file system access. Use the provided tools to help the user.",
+        user_message="Search for all files containing 'func main'",
+        tools=FILE_SEARCH_TOOLS,
+        expected_tool="search_files"
+    ),
+    EvalCase(
+        name="read_config",
+        description="Read a configuration file",
+        system_prompt="You are a helpful assistant with file system access. Use the provided tools to help the user.",
+        user_message="Read the contents of go.mod",
+        tools=FILE_SEARCH_TOOLS,
+        expected_tool="read_file"
+    ),
+]

--- a/testing/evals/cases/general.py
+++ b/testing/evals/cases/general.py
@@ -1,0 +1,95 @@
+"""
+General tool calling test cases.
+"""
+from testing.evals.runner import EvalCase
+
+GENERAL_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "calculator",
+            "description": "Perform mathematical calculations",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {"type": "string", "description": "Mathematical expression to evaluate"}
+                },
+                "required": ["expression"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather information for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"},
+                    "units": {"type": "string", "enum": ["celsius", "fahrenheit"], "description": "Temperature units"}
+                },
+                "required": ["location"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "translate",
+            "description": "Translate text between languages",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string", "description": "Text to translate"},
+                    "target_lang": {"type": "string", "description": "Target language code"},
+                    "source_lang": {"type": "string", "description": "Source language code (optional, auto-detect if not provided)"}
+                },
+                "required": ["text", "target_lang"]
+            }
+        }
+    }
+]
+
+GENERAL_CASES = [
+    EvalCase(
+        name="calculator_add",
+        description="Simple addition calculation",
+        system_prompt="You are a helpful assistant with access to tools. Use them when needed.",
+        user_message="What is 123 + 456?",
+        tools=GENERAL_TOOLS,
+        expected_tool="calculator"
+    ),
+    EvalCase(
+        name="calculator_complex",
+        description="Complex mathematical expression",
+        system_prompt="You are a helpful assistant with access to tools. Use them when needed.",
+        user_message="Calculate (15 * 8) + (100 / 4) - 50",
+        tools=GENERAL_TOOLS,
+        expected_tool="calculator"
+    ),
+    EvalCase(
+        name="get_weather",
+        description="Get weather for a city",
+        system_prompt="You are a helpful assistant with access to tools. Use them when needed.",
+        user_message="What's the weather like in Tokyo?",
+        tools=GENERAL_TOOLS,
+        expected_tool="get_weather"
+    ),
+    EvalCase(
+        name="translate_english_to_spanish",
+        description="Translate text to Spanish",
+        system_prompt="You are a helpful assistant with access to tools. Use them when needed.",
+        user_message="Translate 'Hello, how are you?' to Spanish",
+        tools=GENERAL_TOOLS,
+        expected_tool="translate"
+    ),
+    EvalCase(
+        name="translate_with_source",
+        description="Translate with specified source language",
+        system_prompt="You are a helpful assistant with access to tools. Use them when needed.",
+        user_message="Translate 'Bonjour' from French to English",
+        tools=GENERAL_TOOLS,
+        expected_tool="translate"
+    ),
+]

--- a/testing/evals/main.py
+++ b/testing/evals/main.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Main entry point for running evals.
+Usage: python -m testing.evals.main [--file-search | --general | --all]
+"""
+import argparse
+import glob
+import json
+import os
+from pathlib import Path
+
+from testing.evals.cases.file_search import FILE_SEARCH_CASES
+from testing.evals.cases.general import GENERAL_CASES
+from testing.evals.runner import EvalRunner
+
+
+def get_cwd() -> Path:
+    if hasattr(os, 'getcwd'):
+        return Path(os.getcwd())
+    return Path(".")
+
+
+def mock_tool_executor(tool_name: str, args: dict) -> str:
+    if tool_name == "glob":
+        pattern = args.get("pattern", "")
+        directory = args.get("directory", ".")
+        files = list(Path(directory).glob(pattern))
+        return json.dumps([str(f) for f in files[:10]])
+    
+    if tool_name == "read_file":
+        path = args.get("path", "")
+        try:
+            with open(path, "r") as f:
+                return f.read()[:1000]
+        except FileNotFoundError:
+            return f"File not found: {path}"
+    
+    if tool_name == "search_files":
+        return json.dumps([f"match in {path}" for path in ["file1.go", "file2.go"]])
+    
+    if tool_name == "calculator":
+        expr = args.get("expression", "0")
+        try:
+            result = eval(expr, {"__builtins__": {}}, {})
+            return str(result)
+        except Exception as e:
+            return f"Error: {e}"
+    
+    if tool_name == "get_weather":
+        return json.dumps({"location": args.get("location"), "temp": 72, "condition": "sunny"})
+    
+    if tool_name == "translate":
+        return json.dumps({
+            "original": args.get("text"),
+            "translated": f"[translated: {args.get('text')}]",
+            "target": args.get("target_lang")
+        })
+    
+    return f"Mock result for {tool_name}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run evals against models")
+    parser.add_argument("--file-search", action="store_true", help="Run file search evals only")
+    parser.add_argument("--general", action="store_true", help="Run general tool calling evals only")
+    parser.add_argument("--all", action="store_true", default=True, help="Run all evals (default)")
+    parser.add_argument("--models", default="gpt-oss-20b,nemotron-3-super-120b,qwen3-coder-30b", help="Comma-separated model list")
+    parser.add_argument("--base-url", default="http://pedrogpt:8080/v1", help="API base URL")
+    parser.add_argument("--max-turns", type=int, default=10, help="Max turns per eval")
+    args = parser.parse_args()
+    
+    if args.file_search:
+        cases = FILE_SEARCH_CASES
+        output_file = "file_search_results.json"
+    elif args.general:
+        cases = GENERAL_CASES
+        output_file = "general_results.json"
+    else:
+        cases = FILE_SEARCH_CASES + GENERAL_CASES
+        output_file = "results.json"
+    
+    models = args.models.split(",")
+    
+    runner = EvalRunner(base_url=args.base_url, max_turns=args.max_turns)
+    report = runner.run_evals(cases, models, mock_tool_executor)
+    
+    output_dir = Path("testing/evals/output")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / output_file
+    runner.save_report(report, output_path)
+    
+    print("\n=== Summary ===")
+    for model in models:
+        pass_rate = report.pass_rate(model) * 100
+        print(f"{model}: {pass_rate:.1f}% pass rate")
+    
+    print(f"\nResults saved to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/evals/main.py
+++ b/testing/evals/main.py
@@ -64,7 +64,7 @@ def main():
     parser.add_argument("--file-search", action="store_true", help="Run file search evals only")
     parser.add_argument("--general", action="store_true", help="Run general tool calling evals only")
     parser.add_argument("--all", action="store_true", default=True, help="Run all evals (default)")
-    parser.add_argument("--models", default="gpt-oss-20b,nemotron-3-super-120b,qwen3-coder-30b", help="Comma-separated model list")
+    parser.add_argument("--models", default="nemotron-3-super-120b", help="Comma-separated model list")
     parser.add_argument("--base-url", default="http://pedrogpt:8080/v1", help="API base URL")
     parser.add_argument("--max-turns", type=int, default=10, help="Max turns per eval")
     args = parser.parse_args()

--- a/testing/evals/models.py
+++ b/testing/evals/models.py
@@ -1,0 +1,71 @@
+"""
+Model client for OpenAI-compatible API.
+"""
+import json
+import urllib.request
+import urllib.error
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ModelResult:
+    content: str
+    tool_calls: list[dict[str, Any]]
+    finish_reason: str
+    usage: dict[str, int]
+
+
+class ModelClient:
+    def __init__(self, base_url: str, model: str, api_key: str = "", timeout: int = 60):
+        self.base_url = base_url
+        self.model = model
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def complete(self, messages: list[dict], tools: list[dict] = None, 
+                 temperature: float = 0.0, max_tokens: int = 2048) -> ModelResult:
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        
+        if tools:
+            payload["tools"] = tools
+        
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        
+        req = urllib.request.Request(
+            f"{self.base_url}/chat/completions",
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST"
+        )
+        
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(f"HTTP {e.code}: {e.read().decode('utf-8')}")
+        
+        choice = data["choices"][0]
+        
+        tool_calls = []
+        if choice["message"].get("tool_calls"):
+            for tc in choice["message"]["tool_calls"]:
+                tool_calls.append({
+                    "id": tc["id"],
+                    "name": tc["function"]["name"],
+                    "arguments": tc["function"]["arguments"]
+                })
+        
+        return ModelResult(
+            content=choice["message"].get("content", ""),
+            tool_calls=tool_calls,
+            finish_reason=choice.get("finish_reason", ""),
+            usage=data.get("usage", {})
+        )

--- a/testing/evals/runner.py
+++ b/testing/evals/runner.py
@@ -1,0 +1,179 @@
+"""
+Eval harness runner - runs evals against models sequentially.
+"""
+import json
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from testing.evals.models import ModelClient
+
+
+@dataclass
+class EvalCase:
+    name: str
+    description: str
+    system_prompt: str
+    user_message: str
+    tools: list[dict]
+    expected_tool: str
+    max_turns: int = 10
+
+
+@dataclass
+class EvalResult:
+    case_name: str
+    model_name: str
+    success: bool
+    turns: int
+    tool_calls: list[dict]
+    error: str = ""
+    duration_ms: int = 0
+
+
+@dataclass
+class EvalReport:
+    timestamp: str
+    models: list[str]
+    results: list[EvalResult] = field(default_factory=list)
+
+    def pass_rate(self, model: str) -> float:
+        model_results = [r for r in self.results if r.model_name == model]
+        if not model_results:
+            return 0.0
+        passed = sum(1 for r in model_results if r.success)
+        return passed / len(model_results)
+
+
+class EvalRunner:
+    def __init__(self, base_url: str, max_turns: int = 10):
+        self.base_url = base_url
+        self.max_turns = max_turns
+        self.results: list[EvalResult] = []
+
+    def run_case(self, case: EvalCase, model: str, 
+                 tool_executor: Callable[[str, dict], str]) -> EvalResult:
+        start = time.time()
+        client = ModelClient(self.base_url, model)
+        
+        messages = [
+            {"role": "system", "content": case.system_prompt},
+            {"role": "user", "content": case.user_message},
+        ]
+        
+        tool_calls_made = []
+        turns = 0
+        error = ""
+        
+        try:
+            while turns < case.max_turns:
+                result = client.complete(messages, tools=case.tools)
+                turns += 1
+                
+                if not result.tool_calls:
+                    break
+                
+                for tc in result.tool_calls:
+                    tool_calls_made.append({
+                        "turn": turns,
+                        "name": tc["name"],
+                        "arguments": tc["arguments"]
+                    })
+                    
+                    if tc["name"] == case.expected_tool:
+                        duration_ms = int((time.time() - start) * 1000)
+                        return EvalResult(
+                            case_name=case.name,
+                            model_name=model,
+                            success=True,
+                            turns=turns,
+                            tool_calls=tool_calls_made,
+                            duration_ms=duration_ms
+                        )
+                    
+                    tool_result = tool_executor(tc["name"], json.loads(tc["arguments"]))
+                    messages.append({
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "id": tc["id"],
+                            "type": "function",
+                            "function": {
+                                "name": tc["name"],
+                                "arguments": tc["arguments"]
+                            }
+                        }]
+                    })
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tc["id"],
+                        "content": tool_result
+                    })
+            
+            duration_ms = int((time.time() - start) * 1000)
+            return EvalResult(
+                case_name=case.name,
+                model_name=model,
+                success=False,
+                turns=turns,
+                tool_calls=tool_calls_made,
+                error=f"Expected tool '{case.expected_tool}' not called in {turns} turns",
+                duration_ms=duration_ms
+            )
+            
+        except Exception as e:
+            duration_ms = int((time.time() - start) * 1000)
+            return EvalResult(
+                case_name=case.name,
+                model_name=model,
+                success=False,
+                turns=turns,
+                tool_calls=tool_calls_made,
+                error=str(e),
+                duration_ms=duration_ms
+            )
+
+    def run_evals(self, cases: list[EvalCase], models: list[str],
+                  tool_executor: Callable[[str, dict], str]) -> EvalReport:
+        report = EvalReport(
+            timestamp=datetime.now().isoformat(),
+            models=models
+        )
+        
+        for model in models:
+            print(f"\n=== Testing model: {model} ===")
+            for case in cases:
+                print(f"  Running: {case.name}...", end=" ")
+                result = self.run_case(case, model, tool_executor)
+                self.results.append(result)
+                report.results.append(result)
+                
+                status = "PASS" if result.success else "FAIL"
+                print(f"{status} ({result.turns} turns, {result.duration_ms}ms)")
+                
+                if not result.success:
+                    print(f"    Error: {result.error}")
+        
+        return report
+
+    def save_report(self, report: EvalReport, output_path: Path):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w") as f:
+            json.dump({
+                "timestamp": report.timestamp,
+                "models": report.models,
+                "results": [
+                    {
+                        "case": r.case_name,
+                        "model": r.model_name,
+                        "success": r.success,
+                        "turns": r.turns,
+                        "tool_calls": r.tool_calls,
+                        "error": r.error,
+                        "duration_ms": r.duration_ms
+                    }
+                    for r in report.results
+                ]
+            }, f, indent=2)


### PR DESCRIPTION
## Summary
- Add Python eval framework in `testing/evals/` for testing tool calling across models
- Implement OpenAI-compatible model client
- Add file search test cases (glob, read_file, search_files)
- Add general tool calling test cases (calculator, get_weather, translate)
- Add Makefile targets for running evals

## Results
| Model | Pass Rate |
|-------|-----------|
| gpt-oss-20b | 100% (9/9) |
| qwen3-coder-30b | 55.6% (5/9) |

## Usage
```bash
make evals              # Run all evals
make evals-file-search  # Run file search only
make evals-general      # Run general tests only
```

Models are tested sequentially against http://pedrogpt:8080/v1

## Notes
- nemotron-3-super-120b was loading during testing - can be added once loaded
- qwen3-coder-30b shows inconsistent tool calling (passed some, failed others)
- Results are saved to `testing/evals/output/` (gitignored)