### PR TITLE
Add shared moderation types package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/soypete/pedro-agentware
 
-go 1.25.5
+go 1.26
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/middleware/types_aliases.go
+++ b/middleware/types_aliases.go
@@ -2,9 +2,29 @@ package middleware
 
 import (
 	"github.com/soypete/pedro-agentware/middleware/types"
+
+	"github.com/soypete/pedro-agentware/moderation"
 )
 
 type Action = types.Action
+
+type ModerationDecision = moderation.ModerationDecision
+type TimeoutUserParams = moderation.TimeoutUserParams
+type BanUserParams = moderation.BanUserParams
+type UnbanUserParams = moderation.UnbanUserParams
+type ModeratorParams = moderation.ModeratorParams
+type VIPParams = moderation.VIPParams
+type DeleteMessageParams = moderation.DeleteMessageParams
+type ChatModeParams = moderation.ChatModeParams
+type PollParams = moderation.PollParams
+type EndPollParams = moderation.EndPollParams
+type PredictionParams = moderation.PredictionParams
+type ResolvePredictionParams = moderation.ResolvePredictionParams
+type CancelPredictionParams = moderation.CancelPredictionParams
+type AnnouncementParams = moderation.AnnouncementParams
+type ShoutoutParams = moderation.ShoutoutParams
+type NoActionParams = moderation.NoActionParams
+type WarnUserParams = moderation.WarnUserParams
 
 const (
 	ActionAllow  = types.ActionAllow

--- a/moderation/types.go
+++ b/moderation/types.go
@@ -1,0 +1,112 @@
+package moderation
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ModAction struct {
+	ID                    uuid.UUID       `db:"id"`
+	CreatedAt             time.Time       `db:"created_at"`
+	TriggerMessageID      string          `db:"trigger_message_id"`
+	TriggerUsername       string          `db:"trigger_username"`
+	TriggerMessageContent string          `db:"trigger_message_content"`
+	LLMModel              string          `db:"llm_model"`
+	LLMReasoning          string          `db:"llm_reasoning"`
+	ToolCallName          string          `db:"tool_call_name"`
+	ToolCallParams        json.RawMessage `db:"tool_call_params"`
+	TargetUsername        string          `db:"target_username"`
+	TargetUserID          string          `db:"target_user_id"`
+	TwitchAPIResponse     json.RawMessage `db:"twitch_api_response"`
+	Success               bool            `db:"success"`
+	ErrorMessage          string          `db:"error_message"`
+	ChannelID             string          `db:"channel_id"`
+	ChannelName           string          `db:"channel_name"`
+}
+
+type ModerationDecision struct {
+	ShouldAct    bool
+	ToolCall     string
+	ToolParams   map[string]interface{}
+	Reasoning    string
+	TargetUserID string
+}
+
+type TimeoutUserParams struct {
+	Username        string `json:"username"`
+	DurationSeconds int    `json:"duration_seconds"`
+	Reason          string `json:"reason"`
+}
+
+type BanUserParams struct {
+	Username string `json:"username"`
+	Reason   string `json:"reason"`
+}
+
+type UnbanUserParams struct {
+	Username string `json:"username"`
+}
+
+type ModeratorParams struct {
+	Username string `json:"username"`
+}
+
+type VIPParams struct {
+	Username string `json:"username"`
+}
+
+type DeleteMessageParams struct {
+	MessageID string `json:"message_id"`
+}
+
+type ChatModeParams struct {
+	Enabled         bool `json:"enabled"`
+	DurationMinutes int  `json:"duration_minutes,omitempty"`
+	DelaySeconds    int  `json:"delay_seconds,omitempty"`
+}
+
+type PollParams struct {
+	Title           string   `json:"title"`
+	Choices         []string `json:"choices"`
+	DurationSeconds int      `json:"duration_seconds"`
+}
+
+type EndPollParams struct {
+	PollID string `json:"poll_id"`
+	Status string `json:"status"`
+}
+
+type PredictionParams struct {
+	Title           string   `json:"title"`
+	Outcomes        []string `json:"outcomes"`
+	DurationSeconds int      `json:"duration_seconds"`
+}
+
+type ResolvePredictionParams struct {
+	PredictionID     string `json:"prediction_id"`
+	WinningOutcomeID string `json:"winning_outcome_id"`
+}
+
+type CancelPredictionParams struct {
+	PredictionID string `json:"prediction_id"`
+}
+
+type AnnouncementParams struct {
+	Message string `json:"message"`
+	Color   string `json:"color"`
+}
+
+type ShoutoutParams struct {
+	Username string `json:"username"`
+}
+
+type NoActionParams struct {
+	Reason string `json:"reason"`
+}
+
+type WarnUserParams struct {
+	Username string `json:"username"`
+	Message  string `json:"message"`
+}


### PR DESCRIPTION
## Summary
- Creates `moderation/types.go` with common moderation types (ModAction, ModerationDecision, tool params) that can be shared between pedro-agentware and iam_pedro
- Adds type aliases in `middleware/types_aliases.go` for backward compatibility
- Follows existing pattern used by `middleware/types` package
- Enables iam_pedro to import from pedro-agentware instead of duplicating types

## Changes
- New `moderation/types.go` package with moderation tool params and decision types
- Updated `go.mod` to Go 1.26 and added uuid dependency
- Added aliases in `middleware/types_aliases.go`