### PR TITLE
feat(go): Add MessageType enum and MessageMeta struct

### DIFF
--- a/go/llm/request.go
+++ b/go/llm/request.go
@@ -1,5 +1,28 @@
 package llm
 
+type MessageType string
+
+const (
+	MessageTypeSystemPrompt      MessageType = "system_prompt"
+	MessageTypeUserInput         MessageType = "user_input"
+	MessageTypeToolCall          MessageType = "tool_call"
+	MessageTypeToolResult        MessageType = "tool_result"
+	MessageTypeReasoning         MessageType = "reasoning"
+	MessageTypeTextResponse      MessageType = "text_response"
+	MessageTypeStepNudge         MessageType = "step_nudge"
+	MessageTypePrerequisiteNudge MessageType = "prerequisite_nudge"
+	MessageTypeRetryNudge        MessageType = "retry_nudge"
+	MessageTypeContextWarning    MessageType = "context_warning"
+	MessageTypeSummary           MessageType = "summary"
+)
+
+type MessageMeta struct {
+	Type          MessageType
+	StepIndex     *int
+	OriginalType  *MessageType
+	TokenEstimate *int
+}
+
 // Request is the input to a completion.
 type Request struct {
 	Messages    []Message
@@ -15,6 +38,7 @@ type Message struct {
 	Content    string
 	ToolCallID string
 	ToolCalls  []ToolCall
+	Meta       MessageMeta
 }
 
 // Role represents the role of a message sender.

--- a/go/llm/request_test.go
+++ b/go/llm/request_test.go
@@ -88,3 +88,101 @@ func TestToolDefinition(t *testing.T) {
 		t.Errorf("expected 'object', got '%v'", def.InputSchema["type"])
 	}
 }
+
+func TestMessageTypeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"MessageTypeSystemPrompt", "system_prompt"},
+		{"MessageTypeUserInput", "user_input"},
+		{"MessageTypeToolCall", "tool_call"},
+		{"MessageTypeToolResult", "tool_result"},
+		{"MessageTypeReasoning", "reasoning"},
+		{"MessageTypeTextResponse", "text_response"},
+		{"MessageTypeStepNudge", "step_nudge"},
+		{"MessageTypePrerequisiteNudge", "prerequisite_nudge"},
+		{"MessageTypeRetryNudge", "retry_nudge"},
+		{"MessageTypeContextWarning", "context_warning"},
+		{"MessageTypeSummary", "summary"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mt MessageType
+			switch tt.name {
+			case "MessageTypeSystemPrompt":
+				mt = MessageTypeSystemPrompt
+			case "MessageTypeUserInput":
+				mt = MessageTypeUserInput
+			case "MessageTypeToolCall":
+				mt = MessageTypeToolCall
+			case "MessageTypeToolResult":
+				mt = MessageTypeToolResult
+			case "MessageTypeReasoning":
+				mt = MessageTypeReasoning
+			case "MessageTypeTextResponse":
+				mt = MessageTypeTextResponse
+			case "MessageTypeStepNudge":
+				mt = MessageTypeStepNudge
+			case "MessageTypePrerequisiteNudge":
+				mt = MessageTypePrerequisiteNudge
+			case "MessageTypeRetryNudge":
+				mt = MessageTypeRetryNudge
+			case "MessageTypeContextWarning":
+				mt = MessageTypeContextWarning
+			case "MessageTypeSummary":
+				mt = MessageTypeSummary
+			}
+			if string(mt) != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, mt)
+			}
+		})
+	}
+}
+
+func TestMessageMeta(t *testing.T) {
+	stepIndex := 1
+	originalType := MessageTypeToolCall
+	tokenEstimate := 150
+
+	meta := MessageMeta{
+		Type:          MessageTypeToolResult,
+		StepIndex:     &stepIndex,
+		OriginalType:  &originalType,
+		TokenEstimate: &tokenEstimate,
+	}
+
+	if meta.Type != MessageTypeToolResult {
+		t.Errorf("expected MessageTypeToolResult, got '%s'", meta.Type)
+	}
+	if *meta.StepIndex != 1 {
+		t.Errorf("expected StepIndex 1, got %d", *meta.StepIndex)
+	}
+	if *meta.OriginalType != MessageTypeToolCall {
+		t.Errorf("expected OriginalType ToolCall, got '%s'", *meta.OriginalType)
+	}
+	if *meta.TokenEstimate != 150 {
+		t.Errorf("expected TokenEstimate 150, got %d", *meta.TokenEstimate)
+	}
+}
+
+func TestMessageMetaZeroValue(t *testing.T) {
+	msg := Message{
+		Role:    RoleUser,
+		Content: "Hello",
+	}
+
+	if msg.Meta.Type != "" {
+		t.Errorf("expected empty MessageType, got '%s'", msg.Meta.Type)
+	}
+	if msg.Meta.StepIndex != nil {
+		t.Errorf("expected nil StepIndex, got '%v'", msg.Meta.StepIndex)
+	}
+	if msg.Meta.OriginalType != nil {
+		t.Errorf("expected nil OriginalType, got '%v'", msg.Meta.OriginalType)
+	}
+	if msg.Meta.TokenEstimate != nil {
+		t.Errorf("expected nil TokenEstimate, got '%v'", msg.Meta.TokenEstimate)
+	}
+}


### PR DESCRIPTION
## Summary

Add typed metadata to the Go `Message` struct. This is the foundational change that enables TieredCompact and the guardrails layer.

## Changes

- Add `MessageType` enum with 11 types for semantic message classification
- Add `MessageMeta` struct with `Type`, `StepIndex`, `OriginalType`, `TokenEstimate`
- Add `Meta` field to `Message` struct (backwards-compatible, zero-value safe)
- Add unit tests for MessageType constants and MessageMeta field behavior

## Testing

- All existing tests pass
- New unit tests cover MessageMeta assignment and zero-value behavior

Closes #30