### PR TITLE
Add MessageType enum and MessageMeta to Message dataclass (Issue #31)

### DIFF
--- a/python/src/pedro_agentware/llm/request.py
+++ b/python/src/pedro_agentware/llm/request.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .response import ToolCall
 
+from pedro_agentware.middleware.types import MessageMeta
+
 
 class Role(str, Enum):
     """Message role."""
@@ -25,6 +27,7 @@ class Message:
     content: str = ""
     tool_call_id: str = ""
     tool_calls: list["ToolCall"] = field(default_factory=list)
+    meta: MessageMeta = field(default_factory=MessageMeta)
 
 
 @dataclass

--- a/python/src/pedro_agentware/middleware/types.py
+++ b/python/src/pedro_agentware/middleware/types.py
@@ -6,6 +6,32 @@ from enum import Enum
 from typing import Any
 
 
+class MessageType(str, Enum):
+    """Semantic type of a message for smart compaction and guardrails."""
+
+    SYSTEM_PROMPT = "system_prompt"
+    USER_INPUT = "user_input"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    REASONING = "reasoning"
+    TEXT_RESPONSE = "text_response"
+    STEP_NUDGE = "step_nudge"
+    PREREQUISITE_NUDGE = "prerequisite_nudge"
+    RETRY_NUDGE = "retry_nudge"
+    CONTEXT_WARNING = "context_warning"
+    SUMMARY = "summary"
+
+
+@dataclass(frozen=True)
+class MessageMeta:
+    """Metadata for a message used in smart compaction and guardrails."""
+
+    type: MessageType = MessageType.USER_INPUT
+    step_index: int | None = None
+    original_type: MessageType | None = None
+    token_estimate: int | None = None
+
+
 class Action(str, Enum):
     """Action to take on a tool call."""
 

--- a/python/tests/message_types_test.py
+++ b/python/tests/message_types_test.py
@@ -1,0 +1,91 @@
+"""Tests for MessageType, MessageMeta, and Message types."""
+
+import pytest
+
+from pedro_agentware.llm.request import Message, Role
+from pedro_agentware.middleware.types import MessageMeta, MessageType
+
+
+class TestMessageType:
+    """Tests for MessageType enum."""
+
+    def test_all_types_defined(self):
+        """Verify all 11 MessageType variants are defined."""
+        expected_types = [
+            "system_prompt",
+            "user_input",
+            "tool_call",
+            "tool_result",
+            "reasoning",
+            "text_response",
+            "step_nudge",
+            "prerequisite_nudge",
+            "retry_nudge",
+            "context_warning",
+            "summary",
+        ]
+        actual_types = [mt.value for mt in MessageType]
+        assert sorted(actual_types) == sorted(expected_types)
+
+    def test_message_type_is_str_enum(self):
+        """Verify MessageType inherits from str for easy serialization."""
+        assert isinstance(MessageType.USER_INPUT, str)
+        assert MessageType.USER_INPUT == "user_input"
+
+
+class TestMessageMeta:
+    """Tests for MessageMeta dataclass."""
+
+    def test_default_values(self):
+        """Verify default values for MessageMeta."""
+        meta = MessageMeta()
+        assert meta.type == MessageType.USER_INPUT
+        assert meta.step_index is None
+        assert meta.original_type is None
+        assert meta.token_estimate is None
+
+    def test_custom_values(self):
+        """Verify MessageMeta accepts custom values."""
+        meta = MessageMeta(
+            type=MessageType.TOOL_RESULT,
+            step_index=5,
+            original_type=MessageType.TOOL_CALL,
+            token_estimate=150,
+        )
+        assert meta.type == MessageType.TOOL_RESULT
+        assert meta.step_index == 5
+        assert meta.original_type == MessageType.TOOL_CALL
+        assert meta.token_estimate == 150
+
+    def test_frozen(self):
+        """Verify MessageMeta is frozen (immutable)."""
+        from dataclasses import FrozenInstanceError
+
+        meta = MessageMeta(type=MessageType.REASONING)
+        with pytest.raises((AttributeError, FrozenInstanceError)):
+            meta.type = MessageType.TOOL_CALL
+
+
+class TestMessage:
+    """Tests for Message dataclass with meta field."""
+
+    def test_default_meta(self):
+        """Verify Message has default meta field."""
+        msg = Message(role=Role.USER, content="Hello")
+        assert msg.meta == MessageMeta()
+        assert msg.meta.type == MessageType.USER_INPUT
+
+    def test_custom_meta(self):
+        """Verify Message accepts custom meta."""
+        meta = MessageMeta(type=MessageType.SYSTEM_PROMPT, step_index=0)
+        msg = Message(role=Role.SYSTEM, content="You are helpful", meta=meta)
+        assert msg.meta.type == MessageType.SYSTEM_PROMPT
+        assert msg.meta.step_index == 0
+
+    def test_backward_compatibility(self):
+        """Verify Message can be created without meta (backward compatible)."""
+        msg = Message(role=Role.ASSISTANT, content="Response", tool_call_id="call_123")
+        assert msg.role == Role.ASSISTANT
+        assert msg.content == "Response"
+        assert msg.tool_call_id == "call_123"
+        assert msg.meta == MessageMeta()


### PR DESCRIPTION
## Summary

Adds typed metadata to the Python `Message` dataclass - mirrors the Go implementation in the paired issue.

## Changes

- **MessageType enum** (): 11 types for smart compaction and guardrails
- **MessageMeta dataclass** (): frozen, with type, step_index, original_type, token_estimate
- **Message.meta field** (): added with default factory for backward compatibility
- **Unit tests** (): 8 tests covering new types and backward compatibility

## Acceptance Criteria

- [x] MessageType enum with all 11 types in types.py
- [x] MessageMeta frozen dataclass defined
- [x] Message.meta field added with safe default
- [x] All existing tests pass
- [x] New unit tests cover MessageMeta assignment and default behavior

Closes #31