### PR TITLE
[Go] Implement TieredCompact 3-phase compaction strategy

### DIFF
--- a/go/llm/compact.go
+++ b/go/llm/compact.go
@@ -1,0 +1,237 @@
+package llm
+
+import "errors"
+
+var ErrEmptyMessages = errors.New("no messages to compact")
+
+type TokenCounter func([]Message) int
+
+type CompactionStrategy interface {
+	Compact(messages []Message, targetTokens int, counter TokenCounter) ([]Message, error)
+	Name() string
+}
+
+type TieredCompact struct {
+	KeepRecent      int
+	PhaseThresholds [3]float64
+	TruncateChars   int
+}
+
+func NewTieredCompact() *TieredCompact {
+	return &TieredCompact{
+		KeepRecent:      2,
+		PhaseThresholds: [3]float64{0.75, 0.75, 0.75},
+		TruncateChars:   200,
+	}
+}
+
+func (t *TieredCompact) Name() string {
+	return "TieredCompact"
+}
+
+func (t *TieredCompact) Compact(messages []Message, targetTokens int, counter TokenCounter) ([]Message, error) {
+	if len(messages) == 0 {
+		return nil, ErrEmptyMessages
+	}
+
+	result := make([]Message, len(messages))
+	copy(result, messages)
+
+	eligibleEnd := findEligibleEnd(result, t.KeepRecent)
+
+	currentTokens := counter(result)
+
+	if currentTokens <= targetTokens {
+		return result, nil
+	}
+
+	result = t.phase1Compact(result, eligibleEnd, counter)
+	currentTokens = counter(result)
+	if currentTokens <= targetTokens {
+		return result, nil
+	}
+
+	result = t.phase2Compact(result, eligibleEnd, counter)
+	currentTokens = counter(result)
+	if currentTokens <= targetTokens {
+		return result, nil
+	}
+
+	result = t.phase3Compact(result, eligibleEnd, counter)
+	return result, nil
+}
+
+func findEligibleEnd(messages []Message, keepRecent int) int {
+	if keepRecent <= 0 {
+		return len(messages) - 1
+	}
+
+	maxStep := -1
+	for _, m := range messages {
+		if m.Meta.StepIndex != nil && *m.Meta.StepIndex > maxStep {
+			maxStep = *m.Meta.StepIndex
+		}
+	}
+
+	if maxStep < 0 {
+		protectedCount := keepRecent
+		if protectedCount >= len(messages) {
+			protectedCount = len(messages)
+		}
+		return len(messages) - 1 - protectedCount
+	}
+
+	protectedSteps := make(map[int]bool)
+	currentStep := maxStep
+	for i := 0; i < keepRecent; i++ {
+		protectedSteps[currentStep] = true
+		currentStep--
+		if currentStep < 0 {
+			break
+		}
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		stepIdx := 0
+		if messages[i].Meta.StepIndex != nil {
+			stepIdx = *messages[i].Meta.StepIndex
+		}
+		if !protectedSteps[stepIdx] {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func isNudgeType(msgType MessageType) bool {
+	return msgType == MessageTypeStepNudge ||
+		msgType == MessageTypeRetryNudge ||
+		msgType == MessageTypePrerequisiteNudge
+}
+
+func (t *TieredCompact) protectedSteps(messages []Message) map[int]bool {
+	protected := make(map[int]bool)
+
+	if t.KeepRecent <= 0 {
+		return protected
+	}
+
+	steps := make([]int, 0)
+	stepSet := make(map[int]bool)
+	for _, m := range messages {
+		if m.Meta.StepIndex != nil && !stepSet[*m.Meta.StepIndex] {
+			steps = append(steps, *m.Meta.StepIndex)
+			stepSet[*m.Meta.StepIndex] = true
+		}
+	}
+
+	if len(steps) == 0 {
+		return protected
+	}
+
+	if t.KeepRecent >= len(steps) {
+		for _, s := range steps {
+			protected[s] = true
+		}
+		return protected
+	}
+
+	startIdx := len(steps) - t.KeepRecent
+	for i := startIdx; i < len(steps); i++ {
+		protected[steps[i]] = true
+	}
+
+	return protected
+}
+
+func (t *TieredCompact) isProtected(m *Message, protectedSteps map[int]bool) bool {
+	if m.Meta.StepIndex == nil {
+		return false
+	}
+	return protectedSteps[*m.Meta.StepIndex]
+}
+
+func (t *TieredCompact) phase1Compact(messages []Message, eligibleEnd int, counter TokenCounter) []Message {
+	result := make([]Message, 0, len(messages))
+	protected := t.protectedSteps(messages)
+
+	for i, m := range messages {
+		if i == 0 || i == 1 {
+			result = append(result, m)
+			continue
+		}
+
+		if t.isProtected(&m, protected) {
+			result = append(result, m)
+			continue
+		}
+
+		if isNudgeType(m.Meta.Type) {
+			continue
+		}
+
+		if m.Meta.Type == MessageTypeToolResult {
+			if len(m.Content) > t.TruncateChars {
+				truncated := m
+				truncated.Content = m.Content[:t.TruncateChars]
+				result = append(result, truncated)
+				continue
+			}
+		}
+
+		result = append(result, m)
+	}
+
+	return result
+}
+
+func (t *TieredCompact) phase2Compact(messages []Message, eligibleEnd int, counter TokenCounter) []Message {
+	result := make([]Message, 0, len(messages))
+	protected := t.protectedSteps(messages)
+
+	for i, m := range messages {
+		if i == 0 || i == 1 {
+			result = append(result, m)
+			continue
+		}
+
+		if t.isProtected(&m, protected) {
+			result = append(result, m)
+			continue
+		}
+
+		if m.Meta.Type == MessageTypeToolResult {
+			continue
+		}
+
+		result = append(result, m)
+	}
+
+	return result
+}
+
+func (t *TieredCompact) phase3Compact(messages []Message, eligibleEnd int, counter TokenCounter) []Message {
+	result := make([]Message, 0, len(messages))
+	protected := t.protectedSteps(messages)
+
+	for i, m := range messages {
+		if i == 0 || i == 1 {
+			result = append(result, m)
+			continue
+		}
+
+		if t.isProtected(&m, protected) {
+			result = append(result, m)
+			continue
+		}
+
+		if m.Meta.Type == MessageTypeReasoning || m.Meta.Type == MessageTypeTextResponse {
+			continue
+		}
+
+		result = append(result, m)
+	}
+
+	return result
+}

--- a/go/llm/compact_test.go
+++ b/go/llm/compact_test.go
@@ -1,0 +1,301 @@
+package llm
+
+import (
+	"testing"
+)
+
+func ptrToInt(i int) *int {
+	return &i
+}
+
+func ptrToMessageType(t MessageType) *MessageType {
+	return &t
+}
+
+func TestTieredCompact_Name(t *testing.T) {
+	compact := NewTieredCompact()
+	if compact.Name() != "TieredCompact" {
+		t.Errorf("expected TieredCompact, got %s", compact.Name())
+	}
+}
+
+func TestTieredCompact_Phase1_DropsNudges(t *testing.T) {
+	compact := NewTieredCompact()
+	compact.KeepRecent = 0
+	stepIdx := 0
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system", Meta: MessageMeta{Type: MessageTypeSystemPrompt}},
+		{Role: RoleUser, Content: "user", Meta: MessageMeta{Type: MessageTypeUserInput}},
+		{Role: RoleAssistant, Content: "", Meta: MessageMeta{Type: MessageTypeStepNudge, StepIndex: &stepIdx}},
+		{Role: RoleAssistant, Content: "text", Meta: MessageMeta{Type: MessageTypeTextResponse, StepIndex: &stepIdx}},
+	}
+
+	counter := func(msgs []Message) int {
+		return EstimateMessagesTokens(msgs)
+	}
+
+	result, err := compact.Compact(messages, 5, counter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundNudge := false
+	for _, m := range result {
+		if m.Meta.Type == MessageTypeStepNudge {
+			foundNudge = true
+			break
+		}
+	}
+	if foundNudge {
+		t.Error("expected nudge to be dropped in phase 1")
+	}
+}
+
+func TestTieredCompact_Phase1_TruncatesToolResults(t *testing.T) {
+	compact := NewTieredCompact()
+	compact.KeepRecent = 0
+
+	step0 := 0
+	step1 := 1
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system", Meta: MessageMeta{Type: MessageTypeSystemPrompt, StepIndex: &step0}},
+		{Role: RoleUser, Content: "user", Meta: MessageMeta{Type: MessageTypeUserInput, StepIndex: &step0}},
+		{Role: RoleTool, Content: string(make([]byte, 500)), Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &step0}},
+		{Role: RoleTool, Content: string(make([]byte, 500)), Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &step1}},
+	}
+
+	counter := func(msgs []Message) int {
+		return EstimateMessagesTokens(msgs)
+	}
+
+	result, err := compact.Compact(messages, 150, counter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(result))
+	}
+
+	for _, m := range result {
+		if m.Meta.Type == MessageTypeToolResult && len(m.Content) > 200 {
+			t.Errorf("expected tool_result truncated to 200 chars, got %d", len(m.Content))
+		}
+	}
+}
+
+func TestTieredCompact_Phase2_DropsToolResults(t *testing.T) {
+	compact := NewTieredCompact()
+	compact.KeepRecent = 0
+	stepIdx := 0
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system", Meta: MessageMeta{Type: MessageTypeSystemPrompt}},
+		{Role: RoleUser, Content: "user", Meta: MessageMeta{Type: MessageTypeUserInput}},
+		{Role: RoleTool, Content: "tool result", Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &stepIdx}},
+		{Role: RoleAssistant, Content: "text", Meta: MessageMeta{Type: MessageTypeTextResponse, StepIndex: &stepIdx}},
+	}
+
+	counter := func(msgs []Message) int {
+		return EstimateMessagesTokens(msgs)
+	}
+
+	result, err := compact.Compact(messages, 5, counter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundToolResult := false
+	for _, m := range result {
+		if m.Meta.Type == MessageTypeToolResult {
+			foundToolResult = true
+			break
+		}
+	}
+	if foundToolResult {
+		t.Error("expected tool_result to be dropped in phase 2")
+	}
+}
+
+func TestTieredCompact_Phase3_DropsReasoningAndText(t *testing.T) {
+	compact := NewTieredCompact()
+	compact.KeepRecent = 0
+	stepIdx := 0
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system", Meta: MessageMeta{Type: MessageTypeSystemPrompt}},
+		{Role: RoleUser, Content: "user", Meta: MessageMeta{Type: MessageTypeUserInput}},
+		{Role: RoleTool, Content: "tool result", Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &stepIdx}},
+		{Role: RoleAssistant, Content: "reasoning", Meta: MessageMeta{Type: MessageTypeReasoning, StepIndex: &stepIdx}},
+		{Role: RoleAssistant, Content: "text response", Meta: MessageMeta{Type: MessageTypeTextResponse, StepIndex: &stepIdx}},
+		{Role: RoleAssistant, Content: "", ToolCalls: []ToolCall{{Name: "test"}}, Meta: MessageMeta{Type: MessageTypeToolCall, StepIndex: &stepIdx}},
+	}
+
+	counter := func(msgs []Message) int {
+		return EstimateMessagesTokens(msgs)
+	}
+
+	result, err := compact.Compact(messages, 2, counter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, m := range result {
+		if m.Meta.Type == MessageTypeReasoning || m.Meta.Type == MessageTypeTextResponse {
+			t.Errorf("expected %s to be dropped in phase 3", m.Meta.Type)
+		}
+	}
+}
+
+func TestTieredCompact_ProtectsSystemAndUser(t *testing.T) {
+	compact := NewTieredCompact()
+	compact.KeepRecent = 0
+	stepIdx := 0
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system prompt", Meta: MessageMeta{Type: MessageTypeSystemPrompt}},
+		{Role: RoleUser, Content: "user input", Meta: MessageMeta{Type: MessageTypeUserInput}},
+		{Role: RoleAssistant, Content: "", Meta: MessageMeta{Type: MessageTypeStepNudge, StepIndex: &stepIdx}},
+	}
+
+	counter := func(msgs []Message) int {
+		return EstimateMessagesTokens(msgs)
+	}
+
+	result, err := compact.Compact(messages, 1, counter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 messages (system+user protected), got %d", len(result))
+	}
+
+	if result[0].Meta.Type != MessageTypeSystemPrompt {
+		t.Error("system prompt should be preserved")
+	}
+	if result[1].Meta.Type != MessageTypeUserInput {
+		t.Error("user input should be preserved")
+	}
+}
+
+func TestTieredCompact_KeepRecent(t *testing.T) {
+	compact := NewTieredCompact()
+	compact.KeepRecent = 2
+
+	step0 := 0
+	step1 := 1
+	step2 := 2
+	step3 := 3
+	step4 := 4
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system", Meta: MessageMeta{Type: MessageTypeSystemPrompt}},
+		{Role: RoleUser, Content: "user", Meta: MessageMeta{Type: MessageTypeUserInput}},
+		{Role: RoleTool, Content: "tool0", Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &step0}},
+		{Role: RoleTool, Content: "tool1", Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &step1}},
+		{Role: RoleTool, Content: "tool2", Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &step2}},
+		{Role: RoleTool, Content: "tool3", Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &step3}},
+		{Role: RoleTool, Content: "tool4", Meta: MessageMeta{Type: MessageTypeToolResult, StepIndex: &step4}},
+	}
+
+	counter := func(msgs []Message) int {
+		return EstimateMessagesTokens(msgs)
+	}
+
+	result, err := compact.Compact(messages, 1, counter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasStep3 := false
+	hasStep4 := false
+	for _, m := range result {
+		if m.Meta.StepIndex != nil {
+			if *m.Meta.StepIndex == 3 {
+				hasStep3 = true
+			}
+			if *m.Meta.StepIndex == 4 {
+				hasStep4 = true
+			}
+		}
+	}
+
+	if !hasStep3 || !hasStep4 {
+		t.Error("expected steps 3 and 4 to be preserved (keepRecent=2)")
+	}
+}
+
+func TestTieredCompact_EmptyMessages(t *testing.T) {
+	compact := NewTieredCompact()
+
+	counter := func(msgs []Message) int {
+		return EstimateMessagesTokens(msgs)
+	}
+
+	_, err := compact.Compact([]Message{}, 100, counter)
+	if err != ErrEmptyMessages {
+		t.Errorf("expected ErrEmptyMessages, got %v", err)
+	}
+}
+
+func TestFindEligibleEnd_NoStepIndex(t *testing.T) {
+	messages := []Message{
+		{Role: RoleSystem, Content: "system"},
+		{Role: RoleUser, Content: "user"},
+		{Role: RoleAssistant, Content: "msg1"},
+		{Role: RoleAssistant, Content: "msg2"},
+		{Role: RoleAssistant, Content: "msg3"},
+	}
+
+	result := findEligibleEnd(messages, 2)
+	if result != 2 {
+		t.Errorf("expected 2, got %d", result)
+	}
+}
+
+func TestFindEligibleEnd_WithStepIndex(t *testing.T) {
+	step0 := 0
+	step1 := 1
+	step2 := 2
+	step3 := 3
+	step4 := 4
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system", Meta: MessageMeta{StepIndex: &step0}},
+		{Role: RoleUser, Content: "user", Meta: MessageMeta{StepIndex: &step0}},
+		{Role: RoleAssistant, Content: "msg1", Meta: MessageMeta{StepIndex: &step1}},
+		{Role: RoleAssistant, Content: "msg2", Meta: MessageMeta{StepIndex: &step2}},
+		{Role: RoleAssistant, Content: "msg3", Meta: MessageMeta{StepIndex: &step3}},
+		{Role: RoleAssistant, Content: "msg4", Meta: MessageMeta{StepIndex: &step4}},
+	}
+
+	result := findEligibleEnd(messages, 2)
+	if result != 3 {
+		t.Errorf("expected 3 (index of step2), got %d", result)
+	}
+}
+
+func TestIsNudgeType(t *testing.T) {
+	tests := []struct {
+		msgType MessageType
+		want    bool
+	}{
+		{MessageTypeStepNudge, true},
+		{MessageTypeRetryNudge, true},
+		{MessageTypePrerequisiteNudge, true},
+		{MessageTypeToolResult, false},
+		{MessageTypeReasoning, false},
+		{MessageTypeTextResponse, false},
+		{MessageTypeSystemPrompt, false},
+		{MessageTypeUserInput, false},
+	}
+
+	for _, tt := range tests {
+		if got := isNudgeType(tt.msgType); got != tt.want {
+			t.Errorf("isNudgeType(%s) = %v, want %v", tt.msgType, got, tt.want)
+		}
+	}
+}

--- a/go/llm/compact_test.go
+++ b/go/llm/compact_test.go
@@ -4,14 +4,6 @@ import (
 	"testing"
 )
 
-func ptrToInt(i int) *int {
-	return &i
-}
-
-func ptrToMessageType(t MessageType) *MessageType {
-	return &t
-}
-
 func TestTieredCompact_Name(t *testing.T) {
 	compact := NewTieredCompact()
 	if compact.Name() != "TieredCompact" {


### PR DESCRIPTION
## Summary

Implements a  compaction strategy for the Go middleware that prunes messages in semantic priority order across 3 escalating phases.

## Changes

- Added  with:
  -  struct with configurable , , and 
  -  interface implementation
  - Phase 1: drops nudge types (, , ) and truncates  to  (default 200)
  - Phase 2: drops  entirely
  - Phase 3: drops  and  (keeps  skeleton)
  - System prompt (index 0) and user input (index 1) always preserved
  -  protects last N iterations by step_index

- Added comprehensive unit tests in 

## Acceptance Criteria

- [x]  struct implements 
- [x] Phase 1 drops nudge types and truncates tool results
- [x] Phase 2 drops tool results entirely  
- [x] Phase 3 drops reasoning and text response
- [x] System prompt (messages[0]) and user input (messages[1]) always preserved
- [x]  iterations (by step_index) always preserved intact
- [x] Phase thresholds are configurable per-phase
- [x] Unit tests cover all 3 phases, boundary conditions, and keep_recent behavior

Closes #32