### PR TITLE
feat(typescript): implement TieredCompact 3-phase compaction strategy (closes #33)

### DIFF
--- a/typescript/src/llmcontext/index.ts
+++ b/typescript/src/llmcontext/index.ts
@@ -1,1 +1,11 @@
-export { ContextManager, InMemoryContextManager, ToolResultEntry } from "./manager.js";
+export {
+  ContextManager,
+  InMemoryContextManager,
+  ToolResultEntry,
+} from "./manager.js";
+export {
+  CompactionStrategy,
+  TieredCompact,
+  TokenCounter,
+  findEligibleEnd,
+} from "./strategies.js";

--- a/typescript/src/llmcontext/strategies.ts
+++ b/typescript/src/llmcontext/strategies.ts
@@ -1,0 +1,261 @@
+import { Message, Role } from "../llm/request.js";
+import { MessageType } from "../middleware/types.js";
+
+export type TokenCounter = (messages: Message[]) => number;
+
+export interface CompactionStrategy {
+  compact(
+    messages: Message[],
+    targetTokens: number,
+    counter: TokenCounter
+  ): Message[];
+  name(): string;
+}
+
+function isNudgeType(msgType: MessageType): boolean {
+  return (
+    msgType === MessageType.STEP_NUDGE ||
+    msgType === MessageType.RETRY_NUDGE ||
+    msgType === MessageType.PREREQUISITE_NUDGE
+  );
+}
+
+export class TieredCompact implements CompactionStrategy {
+  private keepRecent: number;
+  private truncateChars: number;
+
+  constructor(keepRecent = 2, truncateChars = 200) {
+    this.keepRecent = keepRecent;
+    this.truncateChars = truncateChars;
+  }
+
+  name(): string {
+    return "TieredCompact";
+  }
+
+  compact(
+    messages: Message[],
+    targetTokens: number,
+    counter: TokenCounter
+  ): Message[] {
+    if (!messages || messages.length === 0) {
+      return [];
+    }
+
+    const result = [...messages];
+
+    const eligibleEnd = findEligibleEnd(result, this.keepRecent);
+
+    let currentTokens = counter(result);
+
+    if (currentTokens <= targetTokens) {
+      return result;
+    }
+
+    const phase1Result = this.phase1Compact(result, eligibleEnd, counter);
+    currentTokens = counter(phase1Result);
+    if (currentTokens <= targetTokens) {
+      return phase1Result;
+    }
+
+    const phase2Result = this.phase2Compact(phase1Result, eligibleEnd, counter);
+    currentTokens = counter(phase2Result);
+    if (currentTokens <= targetTokens) {
+      return phase2Result;
+    }
+
+    return this.phase3Compact(phase2Result, eligibleEnd, counter);
+  }
+
+  private protectedSteps(
+    messages: Message[]
+  ): Map<number, boolean> {
+    const protectedSteps = new Map<number, boolean>();
+
+    if (this.keepRecent <= 0) {
+      return protectedSteps;
+    }
+
+    const steps: number[] = [];
+    const stepSet = new Set<number>();
+
+    for (const m of messages) {
+      if (m.meta?.step_index !== undefined && !stepSet.has(m.meta.step_index)) {
+        steps.push(m.meta.step_index);
+        stepSet.add(m.meta.step_index);
+      }
+    }
+
+    if (steps.length === 0) {
+      return protectedSteps;
+    }
+
+    if (this.keepRecent >= steps.length) {
+      for (const s of steps) {
+        protectedSteps.set(s, true);
+      }
+      return protectedSteps;
+    }
+
+    const startIdx = steps.length - this.keepRecent;
+    for (let i = startIdx; i < steps.length; i++) {
+      protectedSteps.set(steps[i], true);
+    }
+
+    return protectedSteps;
+  }
+
+  private isProtected(
+    msg: Message,
+    protectedSteps: Map<number, boolean>
+  ): boolean {
+    if (msg.meta?.step_index === undefined) {
+      return false;
+    }
+    return protectedSteps.get(msg.meta.step_index) ?? false;
+  }
+
+  private phase1Compact(
+    messages: Message[],
+    _eligibleEnd: number,
+    _counter: TokenCounter
+  ): Message[] {
+    const result: Message[] = [];
+    const protectedSteps = this.protectedSteps(messages);
+
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i];
+
+      if (i === 0 || i === 1) {
+        result.push(m);
+        continue;
+      }
+
+      if (this.isProtected(m, protectedSteps)) {
+        result.push(m);
+        continue;
+      }
+
+      if (isNudgeType(m.meta?.type ?? MessageType.USER_INPUT)) {
+        continue;
+      }
+
+      if (m.meta?.type === MessageType.TOOL_RESULT) {
+        if (m.content.length > this.truncateChars) {
+          result.push({
+            ...m,
+            content: m.content.slice(0, this.truncateChars),
+          });
+          continue;
+        }
+      }
+
+      result.push(m);
+    }
+
+    return result;
+  }
+
+  private phase2Compact(
+    messages: Message[],
+    _eligibleEnd: number,
+    _counter: TokenCounter
+  ): Message[] {
+    const result: Message[] = [];
+    const protectedSteps = this.protectedSteps(messages);
+
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i];
+
+      if (i === 0 || i === 1) {
+        result.push(m);
+        continue;
+      }
+
+      if (this.isProtected(m, protectedSteps)) {
+        result.push(m);
+        continue;
+      }
+
+      if (m.meta?.type === MessageType.TOOL_RESULT) {
+        continue;
+      }
+
+      result.push(m);
+    }
+
+    return result;
+  }
+
+  private phase3Compact(
+    messages: Message[],
+    _eligibleEnd: number,
+    _counter: TokenCounter
+  ): Message[] {
+    const result: Message[] = [];
+    const protectedSteps = this.protectedSteps(messages);
+
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i];
+
+      if (i === 0 || i === 1) {
+        result.push(m);
+        continue;
+      }
+
+      if (this.isProtected(m, protectedSteps)) {
+        result.push(m);
+        continue;
+      }
+
+      const msgType = m.meta?.type ?? MessageType.TEXT_RESPONSE;
+      if (msgType === MessageType.REASONING || msgType === MessageType.TEXT_RESPONSE) {
+        continue;
+      }
+
+      result.push(m);
+    }
+
+    return result;
+  }
+}
+
+export function findEligibleEnd(
+  messages: Message[],
+  keepRecent: number
+): number {
+  if (keepRecent <= 0) {
+    return messages.length - 1;
+  }
+
+  let maxStep = -1;
+  for (const m of messages) {
+    if (m.meta?.step_index !== undefined && m.meta.step_index > maxStep) {
+      maxStep = m.meta.step_index;
+    }
+  }
+
+  if (maxStep < 0) {
+    const protectedCount = Math.min(keepRecent, messages.length);
+    return messages.length - 1 - protectedCount;
+  }
+
+  const protectedSteps = new Map<number, boolean>();
+  let currentStep = maxStep;
+  for (let i = 0; i < keepRecent; i++) {
+    protectedSteps.set(currentStep, true);
+    currentStep--;
+    if (currentStep < 0) {
+      break;
+    }
+  }
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const stepIdx = messages[i].meta?.step_index;
+    if (stepIdx === undefined || !protectedSteps.get(stepIdx)) {
+      return i;
+    }
+  }
+
+  return -1;
+}

--- a/typescript/src/llmcontext/strategies.ts
+++ b/typescript/src/llmcontext/strategies.ts
@@ -1,4 +1,4 @@
-import { Message, Role } from "../llm/request.js";
+import { Message } from "../llm/request.js";
 import { MessageType } from "../middleware/types.js";
 
 export type TokenCounter = (messages: Message[]) => number;

--- a/typescript/tests/strategies.test.ts
+++ b/typescript/tests/strategies.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from "@jest/globals";
+import { Message, Role } from "../src/llm/request.js";
+import { MessageType } from "../src/middleware/types.js";
+import { TieredCompact, findEligibleEnd } from "../src/llmcontext/strategies.js";
+
+const simpleTokenCounter = (messages: Message[]): number => {
+  return Math.floor(
+    messages.reduce((sum, m) => sum + m.content.length, 0) / 4
+  );
+};
+
+describe("TieredCompact", () => {
+  describe("name", () => {
+    it("returns TieredCompact", () => {
+      const compact = new TieredCompact();
+      expect(compact.name()).toBe("TieredCompact");
+    });
+  });
+
+  describe("empty messages", () => {
+    it("returns empty array for empty input", () => {
+      const compact = new TieredCompact();
+      const result = compact.compact([], 100, simpleTokenCounter);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("phase1 - drops nudges", () => {
+    it("drops step nudge in phase 1", () => {
+      const compact = new TieredCompact(0);
+
+      const messages: Message[] = [
+        {
+          role: Role.SYSTEM,
+          content: "system",
+          meta: { type: MessageType.SYSTEM_PROMPT },
+        },
+        {
+          role: Role.USER,
+          content: "user",
+          meta: { type: MessageType.USER_INPUT },
+        },
+        {
+          role: Role.ASSISTANT,
+          content: "",
+          meta: { type: MessageType.STEP_NUDGE, step_index: 0 },
+        },
+        {
+          role: Role.ASSISTANT,
+          content: "text",
+          meta: { type: MessageType.TEXT_RESPONSE, step_index: 0 },
+        },
+      ];
+
+      const result = compact.compact(messages, 2, simpleTokenCounter);
+
+      const nudgeFound = result.some((m) => m.meta?.type === MessageType.STEP_NUDGE);
+      expect(nudgeFound).toBe(false);
+    });
+  });
+
+  describe("phase1 - truncates tool results", () => {
+    it("truncates tool result to truncateChars", () => {
+      const compact = new TieredCompact(0, 200);
+
+      const longContent = "x".repeat(500);
+
+      const messages: Message[] = [
+        {
+          role: Role.SYSTEM,
+          content: "system",
+          meta: { type: MessageType.SYSTEM_PROMPT, step_index: 0 },
+        },
+        {
+          role: Role.USER,
+          content: "user",
+          meta: { type: MessageType.USER_INPUT, step_index: 0 },
+        },
+        {
+          role: Role.TOOL,
+          content: longContent,
+          meta: { type: MessageType.TOOL_RESULT, step_index: 0 },
+        },
+        {
+          role: Role.TOOL,
+          content: longContent,
+          meta: { type: MessageType.TOOL_RESULT, step_index: 1 },
+        },
+      ];
+
+      const result = compact.compact(messages, 150, simpleTokenCounter);
+
+      expect(result.length).toBe(4);
+      for (const m of result) {
+        if (m.meta?.type === MessageType.TOOL_RESULT) {
+          expect(m.content.length).toBeLessThanOrEqual(200);
+        }
+      }
+    });
+  });
+
+  describe("phase2 - drops tool results", () => {
+    it("drops tool result entirely in phase 2", () => {
+      const compact = new TieredCompact(0);
+
+      const messages: Message[] = [
+        {
+          role: Role.SYSTEM,
+          content: "system",
+          meta: { type: MessageType.SYSTEM_PROMPT },
+        },
+        {
+          role: Role.USER,
+          content: "user",
+          meta: { type: MessageType.USER_INPUT },
+        },
+        {
+          role: Role.TOOL,
+          content: "tool result",
+          meta: { type: MessageType.TOOL_RESULT, step_index: 0 },
+        },
+        {
+          role: Role.ASSISTANT,
+          content: "text",
+          meta: { type: MessageType.TEXT_RESPONSE, step_index: 0 },
+        },
+      ];
+
+      const result = compact.compact(messages, 5, simpleTokenCounter);
+
+      const toolResultFound = result.some(
+        (m) => m.meta?.type === MessageType.TOOL_RESULT
+      );
+      expect(toolResultFound).toBe(false);
+    });
+  });
+
+  describe("phase3 - drops reasoning and text response", () => {
+    it("drops reasoning and text response in phase 3", () => {
+      const compact = new TieredCompact(0);
+
+      const messages: Message[] = [
+        {
+          role: Role.SYSTEM,
+          content: "system",
+          meta: { type: MessageType.SYSTEM_PROMPT },
+        },
+        {
+          role: Role.USER,
+          content: "user",
+          meta: { type: MessageType.USER_INPUT },
+        },
+        {
+          role: Role.ASSISTANT,
+          content: "reasoning text",
+          meta: { type: MessageType.REASONING, step_index: 0 },
+        },
+        {
+          role: Role.ASSISTANT,
+          content: "text response",
+          meta: { type: MessageType.TEXT_RESPONSE, step_index: 0 },
+        },
+      ];
+
+      const result = compact.compact(messages, 5, simpleTokenCounter);
+
+      const reasoningFound = result.some(
+        (m) => m.meta?.type === MessageType.REASONING
+      );
+      const textResponseFound = result.some(
+        (m) => m.meta?.type === MessageType.TEXT_RESPONSE
+      );
+      expect(reasoningFound).toBe(false);
+      expect(textResponseFound).toBe(false);
+    });
+  });
+
+  describe("protected messages", () => {
+    it("messages 0 and 1 always protected", () => {
+      const compact = new TieredCompact(0);
+
+      const messages: Message[] = [
+        {
+          role: Role.SYSTEM,
+          content: "system",
+          meta: { type: MessageType.SYSTEM_PROMPT },
+        },
+        {
+          role: Role.USER,
+          content: "user",
+          meta: { type: MessageType.USER_INPUT },
+        },
+        {
+          role: Role.ASSISTANT,
+          content: "reasoning",
+          meta: { type: MessageType.REASONING, step_index: 0 },
+        },
+      ];
+
+      const result = compact.compact(messages, 1, simpleTokenCounter);
+
+      expect(result.length).toBeGreaterThanOrEqual(2);
+      expect(result[0].meta?.type).toBe(MessageType.SYSTEM_PROMPT);
+      expect(result[1].meta?.type).toBe(MessageType.USER_INPUT);
+    });
+  });
+
+  describe("keepRecent", () => {
+    it("preserves last keepRecent steps", () => {
+      const compact = new TieredCompact(2);
+
+      const messages: Message[] = [
+        {
+          role: Role.SYSTEM,
+          content: "system",
+          meta: { type: MessageType.SYSTEM_PROMPT, step_index: 0 },
+        },
+        {
+          role: Role.USER,
+          content: "user",
+          meta: { type: MessageType.USER_INPUT, step_index: 0 },
+        },
+        {
+          role: Role.TOOL,
+          content: "tool0",
+          meta: { type: MessageType.TOOL_RESULT, step_index: 0 },
+        },
+        {
+          role: Role.TOOL,
+          content: "tool1",
+          meta: { type: MessageType.TOOL_RESULT, step_index: 1 },
+        },
+        {
+          role: Role.TOOL,
+          content: "tool2",
+          meta: { type: MessageType.TOOL_RESULT, step_index: 2 },
+        },
+        {
+          role: Role.TOOL,
+          content: "tool3",
+          meta: { type: MessageType.TOOL_RESULT, step_index: 3 },
+        },
+        {
+          role: Role.TOOL,
+          content: "tool4",
+          meta: { type: MessageType.TOOL_RESULT, step_index: 4 },
+        },
+      ];
+
+      const result = compact.compact(messages, 1, simpleTokenCounter);
+
+      const step3Preserved = result.some(
+        (m) => m.meta?.step_index === 3
+      );
+      const step4Preserved = result.some(
+        (m) => m.meta?.step_index === 4
+      );
+      expect(step3Preserved).toBe(true);
+      expect(step4Preserved).toBe(true);
+    });
+  });
+
+  describe("no compaction needed", () => {
+    it("returns unchanged when under target", () => {
+      const compact = new TieredCompact();
+
+      const messages: Message[] = [
+        {
+          role: Role.SYSTEM,
+          content: "system prompt",
+          meta: { type: MessageType.SYSTEM_PROMPT },
+        },
+        {
+          role: Role.USER,
+          content: "user input",
+          meta: { type: MessageType.USER_INPUT },
+        },
+      ];
+
+      const result = compact.compact(messages, 100, simpleTokenCounter);
+
+      expect(result.length).toBe(2);
+      expect(result[0].content).toBe("system prompt");
+      expect(result[1].content).toBe("user input");
+    });
+  });
+});
+
+describe("findEligibleEnd", () => {
+  it("returns adjusted index when no steps", () => {
+    const messages: Message[] = [
+      {
+        role: Role.SYSTEM,
+        content: "system",
+        meta: { type: MessageType.SYSTEM_PROMPT },
+      },
+      {
+        role: Role.USER,
+        content: "user",
+        meta: { type: MessageType.USER_INPUT },
+      },
+      {
+        role: Role.ASSISTANT,
+        content: "msg1",
+        meta: { type: MessageType.TEXT_RESPONSE },
+      },
+      {
+        role: Role.ASSISTANT,
+        content: "msg2",
+        meta: { type: MessageType.TEXT_RESPONSE },
+      },
+      {
+        role: Role.ASSISTANT,
+        content: "msg3",
+        meta: { type: MessageType.TEXT_RESPONSE },
+      },
+    ];
+
+    const result = findEligibleEnd(messages, 1);
+    const expected = messages.length - 1 - 1;
+    expect(result).toBe(expected);
+  });
+
+  it("finds boundary with steps", () => {
+    const messages: Message[] = [
+      {
+        role: Role.SYSTEM,
+        content: "system",
+        meta: { type: MessageType.SYSTEM_PROMPT, step_index: 0 },
+      },
+      {
+        role: Role.USER,
+        content: "user",
+        meta: { type: MessageType.USER_INPUT, step_index: 0 },
+      },
+      {
+        role: Role.ASSISTANT,
+        content: "step1",
+        meta: { type: MessageType.REASONING, step_index: 1 },
+      },
+      {
+        role: Role.ASSISTANT,
+        content: "step2",
+        meta: { type: MessageType.REASONING, step_index: 2 },
+      },
+      {
+        role: Role.ASSISTANT,
+        content: "step3",
+        meta: { type: MessageType.REASONING, step_index: 3 },
+      },
+    ];
+
+    const result = findEligibleEnd(messages, 2);
+    expect(result).toBe(2);
+  });
+});


### PR DESCRIPTION
Implements #33 - A 3-phase compaction strategy for TypeScript that prunes messages in semantic priority order.

## Changes

- Added  strategy to 
- Added exports to 
- Added comprehensive unit tests in 

## Features

### 3-Phase Compaction

1. **Phase 1**: Drops nudges (, , ), truncates  to 200 chars
2. **Phase 2**: Drops  entirely  
3. **Phase 3**: Drops  and 

### Protected Messages
-  and  always preserved (system prompt and user input)
-  iterations preserved via 

## Acceptance Criteria

- [x]  implements  protocol
- [x] All 3 phases implemented with correct message type filtering
- [x] system prompt and user input always preserved
- [x]  iterations preserved via step_index
- [x] Phase thresholds configurable
- [x] Unit tests cover all phases and boundary cases (11 tests)

## Testing

All 11 tests pass:
