### PR TITLE
feat(python): add context threshold callbacks with transient warning injection

### DIFF
--- a/go/llm/context_window_test.go
+++ b/go/llm/context_window_test.go
@@ -152,10 +152,7 @@ func TestContextWindowManager_CheckThresholds_ResetsAfterCompact(t *testing.T) {
 
 	mgr.CheckThresholds(ctx, msg)
 
-	_, err := mgr.Compact(msg)
-	if err != nil {
-		t.Fatalf("Compact failed: %v", err)
-	}
+	mgr.Compact(msg)
 
 	mgr.UpdateTokenCount(850)
 

--- a/go/llm/context_window_test.go
+++ b/go/llm/context_window_test.go
@@ -152,7 +152,10 @@ func TestContextWindowManager_CheckThresholds_ResetsAfterCompact(t *testing.T) {
 
 	mgr.CheckThresholds(ctx, msg)
 
-	mgr.Compact(msg)
+	_, err := mgr.Compact(msg)
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
 
 	mgr.UpdateTokenCount(850)
 

--- a/python/src/pedro_agentware/llmcontext/context_window.py
+++ b/python/src/pedro_agentware/llmcontext/context_window.py
@@ -1,5 +1,6 @@
 """Context window management for conversation history."""
 
+from collections.abc import Callable
 import threading
 
 from pedro_agentware.llm import Message
@@ -10,6 +11,18 @@ from pedro_agentware.llmcontext.strategies import (
 )
 
 
+ThresholdCallback = Callable[[int, int, float], str | None]
+
+
+def default_context_warning(tokens: int, budget: int, pct: float) -> str | None:
+    """Default callback for context threshold warnings."""
+    if pct >= 0.80:
+        return "[Context is nearly full. Summarize critical findings and complete current task.]"
+    if pct >= 0.65:
+        return "[Context is filling up. Be concise and front-load important information.]"
+    return None
+
+
 class ContextWindowManager:
     """Manages context window size and compaction for conversation history."""
 
@@ -18,6 +31,8 @@ class ContextWindowManager:
         context_window: int,
         counter: TokenCounter | None = None,
         strategy: CompactionStrategy | None = None,
+        context_thresholds: list[float] | None = None,
+        on_context_threshold: ThresholdCallback | None = None,
     ) -> None:
         self._context_window = context_window
         self._compaction_ratio = 0.75
@@ -27,6 +42,13 @@ class ContextWindowManager:
         )
         self._last_known_tokens: int | None = None
         self._lock = threading.RLock()
+        self._context_thresholds = (
+            sorted(context_thresholds) if context_thresholds else [0.65, 0.80]
+        )
+        self._on_context_threshold = (
+            on_context_threshold if on_context_threshold is not None else default_context_warning
+        )
+        self._fired_thresholds: set[float] = set()
 
     def set_compaction_ratio(self, ratio: float) -> None:
         """Set the ratio of context window at which compaction triggers."""
@@ -65,7 +87,29 @@ class ContextWindowManager:
             target_tokens = int(self._context_window * self._compaction_ratio)
             compacted = self._strategy.compact(messages, target_tokens, self._counter)
             self._last_known_tokens = None
+            self._fired_thresholds = set()
             return compacted
+
+    def check_thresholds(self, messages: list[Message]) -> str | None:
+        """Check if usage has crossed any configured threshold.
+
+        Returns a warning to inject as transient message, or None.
+        Each threshold fires at most once per session; resets after compaction.
+        """
+        with self._lock:
+            current_tokens = self._estimate_tokens(messages)
+            budget = self._context_window
+            if current_tokens == 0 or budget == 0:
+                return None
+
+            pct = current_tokens / budget
+
+            for threshold in reversed(self._context_thresholds):
+                if pct >= threshold:
+                    if threshold not in self._fired_thresholds:
+                        self._fired_thresholds.add(threshold)
+                        return self._on_context_threshold(current_tokens, budget, pct)
+            return None
 
     def _estimate_tokens(self, messages: list[Message]) -> int:
         """Estimate tokens, using actual count if available."""

--- a/python/src/pedro_agentware/llmcontext/context_window.py
+++ b/python/src/pedro_agentware/llmcontext/context_window.py
@@ -1,7 +1,7 @@
 """Context window management for conversation history."""
 
-from collections.abc import Callable
 import threading
+from collections.abc import Callable
 
 from pedro_agentware.llm import Message
 from pedro_agentware.llmcontext.strategies import (
@@ -9,7 +9,6 @@ from pedro_agentware.llmcontext.strategies import (
     TieredCompact,
     TokenCounter,
 )
-
 
 ThresholdCallback = Callable[[int, int, float], str | None]
 

--- a/python/tests/context_window_test.py
+++ b/python/tests/context_window_test.py
@@ -124,3 +124,105 @@ class TestDefaultCounter:
     def test_empty_messages_returns_zero(self):
         count = default_counter([])
         assert count == 0
+
+
+class TestContextWindowManager_CheckThresholds:
+    def test_fires_once_per_threshold(self):
+        def counter(messages):
+            return 850
+
+        mgr = ContextWindowManager(1000, counter, context_thresholds=[0.80])
+        messages = [Message(role=Role.USER, content="test")]
+
+        warning = mgr.check_thresholds(messages)
+        assert warning is not None
+
+        warning = mgr.check_thresholds(messages)
+        assert warning is None
+
+    def test_resets_after_compact(self):
+        def counter(messages):
+            return 850
+
+        mgr = ContextWindowManager(1000, counter, context_thresholds=[0.80])
+        messages = [Message(role=Role.USER, content="test")]
+
+        mgr.check_thresholds(messages)
+
+        mgr.compact(messages)
+
+        mgr.update_token_count(850)
+        warning = mgr.check_thresholds(messages)
+        assert warning is not None
+
+    def test_highest_threshold_fires_first(self):
+        def counter(messages):
+            return 900
+
+        mgr = ContextWindowManager(1000, counter, context_thresholds=[0.50, 0.80, 0.65])
+        messages = [Message(role=Role.USER, content="test")]
+
+        warning = mgr.check_thresholds(messages)
+        assert warning is not None
+        assert "nearly full" in warning
+
+    def test_default_thresholds(self):
+        def counter(messages):
+            return 700
+
+        mgr = ContextWindowManager(1000, counter)
+        messages = [Message(role=Role.USER, content="test")]
+
+        warning = mgr.check_thresholds(messages)
+        assert warning is not None
+        assert "filling up" in warning
+
+    def test_custom_callback(self):
+        def counter(messages):
+            return 850
+
+        called = [False]
+
+        def custom_cb(tokens, budget, pct):
+            called[0] = True
+            return "custom warning"
+
+        mgr = ContextWindowManager(
+            1000, counter, context_thresholds=[0.80], on_context_threshold=custom_cb
+        )
+        messages = [Message(role=Role.USER, content="test")]
+
+        warning = mgr.check_thresholds(messages)
+        assert called[0]
+        assert warning == "custom warning"
+
+    def test_zero_tokens_returns_none(self):
+        mgr = ContextWindowManager(1000, None)
+        messages = [Message(role=Role.USER, content="")]
+
+        warning = mgr.check_thresholds(messages)
+        assert warning is None
+
+
+class TestContextWindowManager_ThreadSafety_CheckThresholds:
+    def test_concurrent_check_thresholds(self):
+        mgr = ContextWindowManager(
+            1000, default_counter, context_thresholds=[0.50]
+        )
+        errors = []
+
+        def worker():
+            try:
+                for i in range(100):
+                    mgr.check_thresholds(make_messages(5))
+                    mgr.update_token_count(i)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0


### PR DESCRIPTION
Implements issue #37.

Adds configurable threshold callbacks to ContextWindowManager. When context usage crosses a configured fraction, optionally inject a transient warning string before the next inference call. Mirrors the Go change.

## Changes (Python)
- Add context_thresholds and on_context_threshold constructor params
- Add check_thresholds() method that returns warning strings
- Each threshold fires at most once, resets after compaction
- Provide default_context_warning callback for common thresholds (65%, 80%)
- Add unit tests matching Go coverage

## Changes (Go)
- Add thresholds and onThreshold options via functional opts pattern
- Add CheckThresholds method that returns warning strings
- Each threshold fires at most once, resets after compaction
- Provide DefaultThresholdCallback for common thresholds
- Add unit tests matching coverage