### PR TITLE
feat(go/llm): add context threshold callbacks with transient warning injection

### DIFF
--- a/go/llm/context_window.go
+++ b/go/llm/context_window.go
@@ -1,8 +1,14 @@
 package llm
 
 import (
+	"context"
+	"sort"
 	"sync"
 )
+
+type ThresholdCallback func(tokens, budget int, pct float64) string
+
+type ContextWindowOption func(*ContextWindowManager)
 
 type ContextWindowManager struct {
 	mu              sync.RWMutex
@@ -10,17 +16,54 @@ type ContextWindowManager struct {
 	compactionRatio float64
 	counter         TokenCounter
 	lastKnownTokens *int
+	thresholds      []float64
+	onThreshold     ThresholdCallback
+	firedThresholds map[float64]struct{}
 }
 
-func NewContextWindowManager(contextWindow int, counter TokenCounter) *ContextWindowManager {
+func NewContextWindowManager(contextWindow int, counter TokenCounter, opts ...ContextWindowOption) *ContextWindowManager {
 	if counter == nil {
 		counter = DefaultCounter
 	}
-	return &ContextWindowManager{
+	m := &ContextWindowManager{
 		contextWindow:   contextWindow,
 		compactionRatio: 0.75,
 		counter:         counter,
 		lastKnownTokens: nil,
+		thresholds:      []float64{0.65, 0.80},
+		onThreshold:     DefaultThresholdCallback,
+		firedThresholds: make(map[float64]struct{}),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+func WithThresholds(thresholds []float64, cb ThresholdCallback) ContextWindowOption {
+	return func(m *ContextWindowManager) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if len(thresholds) > 0 {
+			thresholdsCopy := make([]float64, len(thresholds))
+			copy(thresholdsCopy, thresholds)
+			sort.Float64s(thresholdsCopy)
+			m.thresholds = thresholdsCopy
+		}
+		if cb != nil {
+			m.onThreshold = cb
+		}
+	}
+}
+
+func DefaultThresholdCallback(tokens, budget int, pct float64) string {
+	switch {
+	case pct >= 0.80:
+		return "Context is nearly full. Summarize critical findings now and prioritize completing the current task."
+	case pct >= 0.65:
+		return "Context is filling up. Be concise and front-load important information."
+	default:
+		return ""
 	}
 }
 
@@ -65,7 +108,31 @@ func (m *ContextWindowManager) Compact(messages []Message) ([]Message, error) {
 		return nil, err
 	}
 	m.lastKnownTokens = nil
+	m.firedThresholds = make(map[float64]struct{})
 	return compacted, nil
+}
+
+func (m *ContextWindowManager) CheckThresholds(ctx context.Context, messages []Message) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	currentTokens := m.estimateTokensLocked(messages)
+	budget := m.contextWindow
+	if currentTokens == 0 || budget == 0 {
+		return ""
+	}
+
+	pct := float64(currentTokens) / float64(budget)
+
+	for _, threshold := range m.thresholds {
+		if pct >= threshold {
+			if _, fired := m.firedThresholds[threshold]; !fired {
+				m.firedThresholds[threshold] = struct{}{}
+				return m.onThreshold(currentTokens, budget, pct)
+			}
+		}
+	}
+	return ""
 }
 
 func (m *ContextWindowManager) estimateTokensLocked(messages []Message) int {

--- a/go/llm/context_window_test.go
+++ b/go/llm/context_window_test.go
@@ -152,7 +152,10 @@ func TestContextWindowManager_CheckThresholds_ResetsAfterCompact(t *testing.T) {
 
 	mgr.CheckThresholds(ctx, msg)
 
-	mgr.Compact(msg)
+	_, err := mgr.Compact(msg)
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
 
 	mgr.UpdateTokenCount(850)
 

--- a/go/llm/context_window_test.go
+++ b/go/llm/context_window_test.go
@@ -1,6 +1,7 @@
 package llm
 
 import (
+	"context"
 	"testing"
 )
 
@@ -118,4 +119,132 @@ func TestDefaultCounter(t *testing.T) {
 	if count != expected {
 		t.Errorf("expected %d, got %d", expected, count)
 	}
+}
+
+func TestContextWindowManager_CheckThresholds_FiresOnce(t *testing.T) {
+	counter := func(messages []Message) int {
+		return 850
+	}
+	mgr := NewContextWindowManager(1000, counter, WithThresholds([]float64{0.80}, nil))
+
+	ctx := context.Background()
+	msg := []Message{{Role: RoleUser, Content: "test"}}
+
+	warning := mgr.CheckThresholds(ctx, msg)
+	if warning == "" {
+		t.Error("expected warning at 85% threshold")
+	}
+
+	warning = mgr.CheckThresholds(ctx, msg)
+	if warning != "" {
+		t.Error("threshold should fire only once")
+	}
+}
+
+func TestContextWindowManager_CheckThresholds_ResetsAfterCompact(t *testing.T) {
+	var counter TokenCounter = func(messages []Message) int {
+		return 850
+	}
+	mgr := NewContextWindowManager(1000, counter, WithThresholds([]float64{0.80}, nil))
+
+	ctx := context.Background()
+	msg := []Message{{Role: RoleUser, Content: "test"}}
+
+	mgr.CheckThresholds(ctx, msg)
+
+	mgr.Compact(msg)
+
+	mgr.UpdateTokenCount(850)
+
+	warning := mgr.CheckThresholds(ctx, msg)
+	if warning == "" {
+		t.Error("threshold should fire again after reset following compaction")
+	}
+}
+
+func TestContextWindowManager_CheckThresholds_MultipleThresholdsOrdered(t *testing.T) {
+	counter := func(messages []Message) int {
+		return 900
+	}
+	mgr := NewContextWindowManager(1000, counter, WithThresholds([]float64{0.50, 0.80, 0.65}, nil))
+
+	ctx := context.Background()
+	msg := []Message{{Role: RoleUser, Content: "test"}}
+
+	warning := mgr.CheckThresholds(ctx, msg)
+	if warning == "" {
+		t.Error("expected warning at 90% (triggers 80% first due to sorted order)")
+	}
+
+	if warning != "Context is nearly full. Summarize critical findings now and prioritize completing the current task." {
+		t.Errorf("expected 80%% threshold message, got: %s", warning)
+	}
+}
+
+func TestContextWindowManager_CheckThresholds_DefaultThresholds(t *testing.T) {
+	counter := func(messages []Message) int {
+		return 700
+	}
+	mgr := NewContextWindowManager(1000, counter)
+
+	ctx := context.Background()
+	msg := []Message{{Role: RoleUser, Content: "test"}}
+
+	warning := mgr.CheckThresholds(ctx, msg)
+	if warning == "" {
+		t.Error("expected default 65% warning")
+	}
+}
+
+func TestContextWindowManager_CheckThresholds_CustomCallback(t *testing.T) {
+	counter := func(messages []Message) int {
+		return 850
+	}
+	customCalled := false
+	customCB := func(tokens, budget int, pct float64) string {
+		customCalled = true
+		return "custom warning"
+	}
+	mgr := NewContextWindowManager(1000, counter, WithThresholds([]float64{0.80}, customCB))
+
+	ctx := context.Background()
+	msg := []Message{{Role: RoleUser, Content: "test"}}
+
+	warning := mgr.CheckThresholds(ctx, msg)
+	if !customCalled {
+		t.Error("custom callback should be called")
+	}
+	if warning != "custom warning" {
+		t.Errorf("expected custom warning, got: %s", warning)
+	}
+}
+
+func TestContextWindowManager_CheckThresholds_ZeroTokens(t *testing.T) {
+	mgr := NewContextWindowManager(1000, nil)
+
+	ctx := context.Background()
+	msg := []Message{{Role: RoleUser, Content: ""}}
+
+	warning := mgr.CheckThresholds(ctx, msg)
+	if warning != "" {
+		t.Error("expected empty warning for zero tokens")
+	}
+}
+
+func TestContextWindowManager_ThreadSafety_CheckThresholds(t *testing.T) {
+	mgr := NewContextWindowManager(1000, nil, WithThresholds([]float64{0.50}, nil))
+
+	done := make(chan bool)
+	go func() {
+		for i := 0; i < 1000; i++ {
+			mgr.CheckThresholds(context.Background(), []Message{{Role: RoleUser, Content: "test"}})
+		}
+		done <- true
+	}()
+
+	for i := 0; i < 1000; i++ {
+		mgr.UpdateTokenCount(i)
+	}
+
+	<-done
 }


### PR DESCRIPTION
Implements issue #36.

Adds configurable threshold callbacks to ContextWindowManager. When context usage crosses a configured fraction, optionally inject a transient warning string before the next inference call.

## Changes
- Add ThresholdCallback type
- Add thresholds, onThreshold fields to ContextWindowManager
- Add WithThresholds functional option
- Add CheckThresholds method that fires once per threshold
- Reset fired thresholds after compaction
- Provide DefaultThresholdCallback (65%, 80%)
- Thread-safe, unit tests included