### PR TITLE
Add CompactEvent emission from ContextWindowManager

### DIFF
--- a/go/llm/compact.go
+++ b/go/llm/compact.go
@@ -6,15 +6,35 @@ var ErrEmptyMessages = errors.New("no messages to compact")
 
 type TokenCounter func([]Message) int
 
+type CompactEvent struct {
+	StepIndex      int
+	TokensBefore   int
+	TokensAfter    int
+	BudgetTokens   int
+	MessagesBefore int
+	MessagesAfter  int
+	PhaseReached   int
+	StrategyName   string
+}
+
 type CompactionStrategy interface {
 	Compact(messages []Message, targetTokens int, counter TokenCounter) ([]Message, error)
 	Name() string
+}
+
+type PhaseReporter interface {
+	LastPhase() int
 }
 
 type TieredCompact struct {
 	KeepRecent      int
 	PhaseThresholds [3]float64
 	TruncateChars   int
+	lastPhase       int
+}
+
+func (t *TieredCompact) LastPhase() int {
+	return t.lastPhase
 }
 
 func NewTieredCompact() *TieredCompact {
@@ -42,22 +62,26 @@ func (t *TieredCompact) Compact(messages []Message, targetTokens int, counter To
 	currentTokens := counter(result)
 
 	if currentTokens <= targetTokens {
+		t.lastPhase = 0
 		return result, nil
 	}
 
 	result = t.phase1Compact(result, eligibleEnd, counter)
 	currentTokens = counter(result)
 	if currentTokens <= targetTokens {
+		t.lastPhase = 1
 		return result, nil
 	}
 
 	result = t.phase2Compact(result, eligibleEnd, counter)
 	currentTokens = counter(result)
 	if currentTokens <= targetTokens {
+		t.lastPhase = 2
 		return result, nil
 	}
 
 	result = t.phase3Compact(result, eligibleEnd, counter)
+	t.lastPhase = 3
 	return result, nil
 }
 

--- a/go/llm/context_window.go
+++ b/go/llm/context_window.go
@@ -8,6 +8,8 @@ import (
 
 type ThresholdCallback func(tokens, budget int, pct float64) string
 
+type CompactCallback func(CompactEvent)
+
 type ContextWindowOption func(*ContextWindowManager)
 
 type ContextWindowManager struct {
@@ -18,6 +20,7 @@ type ContextWindowManager struct {
 	lastKnownTokens *int
 	thresholds      []float64
 	onThreshold     ThresholdCallback
+	onCompact       CompactCallback
 	firedThresholds map[float64]struct{}
 }
 
@@ -53,6 +56,14 @@ func WithThresholds(thresholds []float64, cb ThresholdCallback) ContextWindowOpt
 		if cb != nil {
 			m.onThreshold = cb
 		}
+	}
+}
+
+func WithOnCompact(cb CompactCallback) ContextWindowOption {
+	return func(m *ContextWindowManager) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.onCompact = cb
 	}
 }
 
@@ -101,12 +112,41 @@ func (m *ContextWindowManager) Compact(messages []Message) ([]Message, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	targetTokens := int(float64(m.contextWindow) * m.compactionRatio)
+	tokensBefore := m.counter(messages)
+	messagesBefore := len(messages)
+	budgetTokens := m.contextWindow
+	targetTokens := int(float64(budgetTokens) * m.compactionRatio)
 	strategy := NewTieredCompact()
 	compacted, err := strategy.Compact(messages, targetTokens, m.counter)
 	if err != nil {
 		return nil, err
 	}
+	tokensAfter := m.counter(compacted)
+	messagesAfter := len(compacted)
+
+	phaseReached := 1
+	if strategy != nil {
+		phaseReached = strategy.LastPhase()
+	}
+
+	stepIndex := 0
+	if len(messages) > 0 && messages[len(messages)-1].Meta.StepIndex != nil {
+		stepIndex = *messages[len(messages)-1].Meta.StepIndex
+	}
+
+	if m.onCompact != nil {
+		m.onCompact(CompactEvent{
+			StepIndex:      stepIndex,
+			TokensBefore:   tokensBefore,
+			TokensAfter:    tokensAfter,
+			BudgetTokens:   budgetTokens,
+			MessagesBefore: messagesBefore,
+			MessagesAfter:  messagesAfter,
+			PhaseReached:   phaseReached,
+			StrategyName:   strategy.Name(),
+		})
+	}
+
 	m.lastKnownTokens = nil
 	m.firedThresholds = make(map[float64]struct{})
 	return compacted, nil

--- a/go/llm/context_window_test.go
+++ b/go/llm/context_window_test.go
@@ -251,3 +251,99 @@ func TestContextWindowManager_ThreadSafety_CheckThresholds(t *testing.T) {
 
 	<-done
 }
+
+func TestContextWindowManager_Compact_CallbackFires(t *testing.T) {
+	counter := func(messages []Message) int {
+		return 900
+	}
+	var capturedEvent CompactEvent
+	callback := func(event CompactEvent) {
+		capturedEvent = event
+	}
+	mgr := NewContextWindowManager(1000, counter, WithOnCompact(callback))
+
+	messages := []Message{{Role: RoleUser, Content: "test"}}
+	_, err := mgr.Compact(messages)
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
+
+	if capturedEvent.TokensBefore == 0 {
+		t.Error("callback should have been called with TokensBefore set")
+	}
+}
+
+func TestContextWindowManager_Compact_EventContainsCorrectData(t *testing.T) {
+	counter := func(messages []Message) int {
+		return 900
+	}
+	var capturedEvent CompactEvent
+	callback := func(event CompactEvent) {
+		capturedEvent = event
+	}
+	mgr := NewContextWindowManager(1000, counter, WithOnCompact(callback))
+
+	messages := []Message{
+		{Role: RoleSystem, Content: "system"},
+		{Role: RoleUser, Content: "test"},
+		{Role: RoleAssistant, Content: "response"},
+	}
+	_, err := mgr.Compact(messages)
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
+
+	if capturedEvent.BudgetTokens != 1000 {
+		t.Errorf("expected BudgetTokens=1000, got %d", capturedEvent.BudgetTokens)
+	}
+	if capturedEvent.MessagesBefore != 3 {
+		t.Errorf("expected MessagesBefore=3, got %d", capturedEvent.MessagesBefore)
+	}
+	if capturedEvent.StrategyName != "TieredCompact" {
+		t.Errorf("expected StrategyName=TieredCompact, got %s", capturedEvent.StrategyName)
+	}
+	if capturedEvent.PhaseReached == 0 {
+		t.Error("PhaseReached should be set (1 for non-tiered or 1-3 for tiered)")
+	}
+}
+
+func TestContextWindowManager_Compact_NoCallbackSet(t *testing.T) {
+	counter := func(messages []Message) int {
+		return 900
+	}
+	mgr := NewContextWindowManager(1000, counter)
+
+	messages := []Message{{Role: RoleUser, Content: "test"}}
+	_, err := mgr.Compact(messages)
+	if err != nil {
+		t.Fatalf("Compact should not panic with nil callback: %v", err)
+	}
+}
+
+func TestContextWindowManager_Compact_PhaseReachedReflectsPhases(t *testing.T) {
+	stepIndex := 5
+
+	longContent := ""
+	for i := 0; i < 100; i++ {
+		longContent += "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+	}
+
+	messages := make([]Message, 20)
+	for i := range messages {
+		si := stepIndex + i
+		messages[i] = Message{
+			Role:    RoleUser,
+			Content: longContent,
+			Meta: MessageMeta{
+				StepIndex: &si,
+			},
+		}
+	}
+
+	mgr := NewContextWindowManager(1000, DefaultCounter, WithOnCompact(func(event CompactEvent) {}))
+
+	_, err := mgr.Compact(messages)
+	if err != nil {
+		t.Fatalf("Compact failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Emit a `CompactEvent` whenever compaction fires, giving callers observability into when and how aggressively the context was pruned.

## Changes

### New type: `CompactEvent`
- `StepIndex`: Current step index
- `TokensBefore`: Token count before compaction  
- `TokensAfter`: Token count after compaction
- `BudgetTokens`: Total context window budget
- `MessagesBefore`: Message count before compaction
- `MessagesAfter`: Message count after compaction
- `PhaseReached`: 0 = no compaction, 1/2/3 for TieredCompact phases
- `StrategyName`: Name of the compaction strategy used

### Updated `ContextWindowManager`
- Added `onCompact` callback field (optional, no-op if nil)
- Added `WithOnCompact()` option to set the callback
- Updated `Compact()` to emit event after every compaction

### Updated `TieredCompact`
- Added `lastPhase` field to track which phase was reached
- Added `LastPhase()` method to retrieve phase

## Testing
- Added unit tests verifying callback fires with correct data
- All tests pass

Closes #38