### PR TITLE
feat(python): add CompactEvent emission from ContextWindowManager

### DIFF
--- a/python/src/pedro_agentware/llmcontext/__init__.py
+++ b/python/src/pedro_agentware/llmcontext/__init__.py
@@ -1,6 +1,6 @@
 """LLMContext package - Conversation context management."""
 
-from .context_window import ContextWindowManager
+from .context_window import CompactEvent, ContextWindowManager
 from .manager import ContextManager
 
-__all__ = ["ContextManager", "ContextWindowManager"]
+__all__ = ["CompactEvent", "ContextManager", "ContextWindowManager"]

--- a/python/src/pedro_agentware/llmcontext/context_window.py
+++ b/python/src/pedro_agentware/llmcontext/context_window.py
@@ -2,6 +2,7 @@
 
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from pedro_agentware.llm import Message
 from pedro_agentware.llmcontext.strategies import (
@@ -9,6 +10,20 @@ from pedro_agentware.llmcontext.strategies import (
     TieredCompact,
     TokenCounter,
 )
+
+
+@dataclass(frozen=True)
+class CompactEvent:
+    """Event emitted when context compaction occurs."""
+
+    step_index: int
+    tokens_before: int
+    tokens_after: int
+    budget_tokens: int
+    messages_before: int
+    messages_after: int
+    phase_reached: int
+    strategy_name: str
 
 ThresholdCallback = Callable[[int, int, float], str | None]
 
@@ -32,6 +47,7 @@ class ContextWindowManager:
         strategy: CompactionStrategy | None = None,
         context_thresholds: list[float] | None = None,
         on_context_threshold: ThresholdCallback | None = None,
+        on_compact: Callable[[CompactEvent], None] | None = None,
     ) -> None:
         self._context_window = context_window
         self._compaction_ratio = 0.75
@@ -48,6 +64,7 @@ class ContextWindowManager:
             on_context_threshold if on_context_threshold is not None else default_context_warning
         )
         self._fired_thresholds: set[float] = set()
+        self._on_compact = on_compact
 
     def set_compaction_ratio(self, ratio: float) -> None:
         """Set the ratio of context window at which compaction triggers."""
@@ -81,10 +98,33 @@ class ContextWindowManager:
         """Compact messages to fit within target token count.
 
         Returns compacted messages. Resets last_known_tokens after compaction.
+        Emits CompactEvent via on_compact callback if configured.
         """
         with self._lock:
+            tokens_before = self._estimate_tokens(messages)
+            messages_before = len(messages)
             target_tokens = int(self._context_window * self._compaction_ratio)
             compacted = self._strategy.compact(messages, target_tokens, self._counter)
+            tokens_after = self._counter(compacted)
+            messages_after = len(compacted)
+
+            phase_reached = 0
+            if isinstance(self._strategy, TieredCompact):
+                phase_reached = self._strategy.last_phase
+
+            if self._on_compact is not None:
+                event = CompactEvent(
+                    step_index=0,
+                    tokens_before=tokens_before,
+                    tokens_after=tokens_after,
+                    budget_tokens=self._context_window,
+                    messages_before=messages_before,
+                    messages_after=messages_after,
+                    phase_reached=phase_reached,
+                    strategy_name=self._strategy.name(),
+                )
+                self._on_compact(event)
+
             self._last_known_tokens = None
             self._fired_thresholds = set()
             return compacted

--- a/python/src/pedro_agentware/llmcontext/strategies.py
+++ b/python/src/pedro_agentware/llmcontext/strategies.py
@@ -53,6 +53,7 @@ class TieredCompact:
     keep_recent: int = 2
     phase_thresholds: tuple[float, float, float] | None = None
     truncate_chars: int = 200
+    last_phase: int = 0
 
     def __post_init__(self) -> None:
         if self.phase_thresholds is None:
@@ -65,6 +66,8 @@ class TieredCompact:
         self, messages: list[Message], target_tokens: int, counter: TokenCounter
     ) -> list[Message]:
         """Compact messages using 3-phase tiered strategy."""
+        self.last_phase = 0
+
         if not messages:
             return []
 
@@ -79,15 +82,18 @@ class TieredCompact:
 
         result = self._phase1_compact(result, eligible_end, counter)
         current_tokens = counter(result)
+        self.last_phase = 1
         if current_tokens <= target_tokens:
             return result
 
         result = self._phase2_compact(result, eligible_end, counter)
         current_tokens = counter(result)
+        self.last_phase = 2
         if current_tokens <= target_tokens:
             return result
 
         result = self._phase3_compact(result, eligible_end, counter)
+        self.last_phase = 3
         return result
 
     def _protected_steps(self, messages: list[Message]) -> dict[int, bool]:

--- a/python/tests/context_window_test.py
+++ b/python/tests/context_window_test.py
@@ -3,7 +3,11 @@
 import threading
 
 from pedro_agentware.llm import Message, Role
-from pedro_agentware.llmcontext.context_window import ContextWindowManager, default_counter
+from pedro_agentware.llmcontext.context_window import (
+    CompactEvent,
+    ContextWindowManager,
+    default_counter,
+)
 
 
 def make_messages(count: int) -> list[Message]:
@@ -226,3 +230,67 @@ class TestContextWindowManager_ThreadSafety_CheckThresholds:
             t.join()
 
         assert len(errors) == 0
+
+
+class TestCompactEvent:
+    def test_compact_event_fired_on_compact(self):
+        received_events: list[CompactEvent] = []
+
+        def on_compact(event: CompactEvent):
+            received_events.append(event)
+
+        mgr = ContextWindowManager(1000, default_counter, on_compact=on_compact)
+        mgr.set_compaction_ratio(0.5)
+        messages = make_messages(10)
+
+        compacted = mgr.compact(messages)
+
+        assert len(received_events) == 1
+        event = received_events[0]
+        assert event.messages_before == 10
+        assert event.messages_after <= 10
+        assert event.tokens_before >= event.tokens_after
+        assert event.budget_tokens == 1000
+        assert event.strategy_name == "TieredCompact"
+
+    def test_compact_event_not_fired_without_callback(self):
+        mgr = ContextWindowManager(1000, default_counter)
+        mgr.set_compaction_ratio(0.5)
+        messages = make_messages(10)
+
+        compacted = mgr.compact(messages)
+
+        assert isinstance(compacted, list)
+
+    def test_compact_event_phase_reached(self):
+        received_events: list[CompactEvent] = []
+
+        def on_compact(event: CompactEvent):
+            received_events.append(event)
+
+        mgr = ContextWindowManager(1000, default_counter, on_compact=on_compact)
+        mgr.set_compaction_ratio(0.1)
+        messages = make_messages(20)
+
+        mgr.compact(messages)
+
+        assert len(received_events) == 1
+        assert received_events[0].phase_reached > 0
+
+    def test_compact_event_zero_phase_when_no_compaction_needed(self):
+        received_events: list[CompactEvent] = []
+
+        def on_compact(event: CompactEvent):
+            received_events.append(event)
+
+        def counter(messages: list[Message]) -> int:
+            return 100
+
+        mgr = ContextWindowManager(1000, counter, on_compact=on_compact)
+        mgr.set_compaction_ratio(0.5)
+        messages = make_messages(3)
+
+        mgr.compact(messages)
+
+        assert len(received_events) == 1
+        assert received_events[0].phase_reached == 0


### PR DESCRIPTION
## Summary

Emit a `CompactEvent` dataclass whenever compaction fires in the Python middleware.

## Changes

- Add `CompactEvent` frozen dataclass with:
  - step_index, tokens_before/after, budget_tokens, messages_before/after
  - phase_reached (0-3), strategy_name
- Add `on_compact` callback parameter to `ContextWindowManager.__init__`
- Add `last_phase` field to `TieredCompact` to track compaction phase
- Emit `CompactEvent` in `compact()` with accurate token/message counts
- Add unit tests for callback firing and event data

Closes #39