### PR TITLE
feat(typescript): add CompactEvent emission from ContextWindowManager

### DIFF
--- a/typescript/src/llmcontext/context_window.ts
+++ b/typescript/src/llmcontext/context_window.ts
@@ -2,6 +2,19 @@ import type { Message } from "../llm/request.js";
 import type { CompactionStrategy, TokenCounter } from "./strategies.js";
 import { TieredCompact } from "./strategies.js";
 
+export interface CompactEvent {
+  step_index: number;
+  tokens_before: number;
+  tokens_after: number;
+  budget_tokens: number;
+  messages_before: number;
+  messages_after: number;
+  phase_reached: number;
+  strategy_name: string;
+}
+
+export type CompactCallback = (event: CompactEvent) => void;
+
 export type ThresholdCallback = (
   tokens: number,
   budget: number,
@@ -31,13 +44,15 @@ export class ContextWindowManager {
   private contextThresholds: number[];
   private onContextThreshold: ThresholdCallback;
   private firedThresholds: Set<number>;
+  private onCompact: CompactCallback | null;
 
   constructor(
     contextWindow: number,
     counter: TokenCounter | null = null,
     strategy: CompactionStrategy | null = null,
     contextThresholds: number[] | null = null,
-    onContextThreshold: ThresholdCallback | null = null
+    onContextThreshold: ThresholdCallback | null = null,
+    onCompact: CompactCallback | null = null
   ) {
     this.contextWindow = contextWindow;
     this.compactionRatio = 0.75;
@@ -49,6 +64,7 @@ export class ContextWindowManager {
       : [0.65, 0.8];
     this.onContextThreshold = onContextThreshold ?? defaultContextWarning;
     this.firedThresholds = new Set();
+    this.onCompact = onCompact;
   }
 
   setCompactionRatio(ratio: number): void {
@@ -72,8 +88,32 @@ export class ContextWindowManager {
   }
 
   compact(messages: Message[]): Message[] {
+    const tokensBefore = this.estimateTokens(messages);
+    const messagesBefore = messages.length;
     const targetTokens = Math.floor(this.contextWindow * this.compactionRatio);
     const compacted = this.strategy.compact(messages, targetTokens, this.counter);
+    const tokensAfter = this.counter(compacted);
+    const messagesAfter = compacted.length;
+
+    let phaseReached = 0;
+    if (this.strategy instanceof TieredCompact) {
+      phaseReached = (this.strategy as TieredCompact).lastPhase;
+    }
+
+    if (this.onCompact !== null) {
+      const event: CompactEvent = {
+        step_index: 0,
+        tokens_before: tokensBefore,
+        tokens_after: tokensAfter,
+        budget_tokens: this.contextWindow,
+        messages_before: messagesBefore,
+        messages_after: messagesAfter,
+        phase_reached: phaseReached,
+        strategy_name: this.strategy.name(),
+      };
+      this.onCompact(event);
+    }
+
     this.lastKnownTokens = null;
     this.firedThresholds.clear();
     return compacted;

--- a/typescript/src/llmcontext/index.ts
+++ b/typescript/src/llmcontext/index.ts
@@ -11,6 +11,8 @@ export {
 } from "./strategies.js";
 export {
   ContextWindowManager,
+  CompactEvent,
+  CompactCallback,
   defaultCounter,
   defaultContextWarning,
   ThresholdCallback,

--- a/typescript/src/llmcontext/strategies.ts
+++ b/typescript/src/llmcontext/strategies.ts
@@ -23,6 +23,7 @@ function isNudgeType(msgType: MessageType): boolean {
 export class TieredCompact implements CompactionStrategy {
   private keepRecent: number;
   private truncateChars: number;
+  public lastPhase: number = 0;
 
   constructor(keepRecent = 2, truncateChars = 200) {
     this.keepRecent = keepRecent;
@@ -38,6 +39,8 @@ export class TieredCompact implements CompactionStrategy {
     targetTokens: number,
     counter: TokenCounter
   ): Message[] {
+    this.lastPhase = 0;
+
     if (!messages || messages.length === 0) {
       return [];
     }
@@ -54,17 +57,21 @@ export class TieredCompact implements CompactionStrategy {
 
     const phase1Result = this.phase1Compact(result, eligibleEnd, counter);
     currentTokens = counter(phase1Result);
+    this.lastPhase = 1;
     if (currentTokens <= targetTokens) {
       return phase1Result;
     }
 
     const phase2Result = this.phase2Compact(phase1Result, eligibleEnd, counter);
     currentTokens = counter(phase2Result);
+    this.lastPhase = 2;
     if (currentTokens <= targetTokens) {
       return phase2Result;
     }
 
-    return this.phase3Compact(phase2Result, eligibleEnd, counter);
+    const phase3Result = this.phase3Compact(phase2Result, eligibleEnd, counter);
+    this.lastPhase = 3;
+    return phase3Result;
   }
 
   private protectedSteps(

--- a/typescript/tests/context_window.test.ts
+++ b/typescript/tests/context_window.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
 import { Message, Role } from "../src/llm/request.js";
 import {
+  CompactEvent,
   ContextWindowManager,
   defaultCounter,
   defaultContextWarning,
@@ -215,5 +216,78 @@ describe("ContextWindowManager_ThreadSafety_CheckThresholds", () => {
     const results = await Promise.all(calls);
     const nonNull = results.filter((r) => r !== null).length;
     expect(nonNull).toBeGreaterThan(0);
+  });
+});
+
+describe("CompactEvent", () => {
+  it("fires on compact when callback provided", () => {
+    const receivedEvents: CompactEvent[] = [];
+    const onCompact = (event: CompactEvent) => receivedEvents.push(event);
+
+    const mgr = new ContextWindowManager(1000, defaultCounter, null, null, null, onCompact);
+    mgr.setCompactionRatio(0.5);
+
+    const messages = Array.from({ length: 10 }, (_, i) => ({
+      role: Role.USER,
+      content: "Message " + i + ": " + "x".repeat(i * 100),
+    }));
+
+    const compacted = mgr.compact(messages);
+
+    expect(receivedEvents.length).toBe(1);
+    const event = receivedEvents[0];
+    expect(event.messages_before).toBe(10);
+    expect(event.messages_after).toBeLessThanOrEqual(10);
+    expect(event.tokens_before).toBeGreaterThanOrEqual(event.tokens_after);
+    expect(event.budget_tokens).toBe(1000);
+    expect(event.strategy_name).toBe("TieredCompact");
+  });
+
+  it("does not fire when no callback provided", () => {
+    const mgr = new ContextWindowManager(1000, defaultCounter);
+    mgr.setCompactionRatio(0.5);
+
+    const messages = Array.from({ length: 10 }, (_, i) => ({
+      role: Role.USER,
+      content: "Message " + i + ": " + "x".repeat(i * 100),
+    }));
+
+    const compacted = mgr.compact(messages);
+
+    expect(compacted).toBeDefined();
+  });
+
+  it("captures phase reached", () => {
+    const receivedEvents: CompactEvent[] = [];
+    const onCompact = (event: CompactEvent) => receivedEvents.push(event);
+
+    const mgr = new ContextWindowManager(1000, defaultCounter, null, null, null, onCompact);
+    mgr.setCompactionRatio(0.1);
+
+    const messages = Array.from({ length: 20 }, (_, i) => ({
+      role: Role.USER,
+      content: "Message " + i + ": " + "x".repeat(i * 100),
+    }));
+
+    mgr.compact(messages);
+
+    expect(receivedEvents.length).toBe(1);
+    expect(receivedEvents[0].phase_reached).toBeGreaterThan(0);
+  });
+
+  it("reports zero phase when no compaction needed", () => {
+    const receivedEvents: CompactEvent[] = [];
+    const onCompact = (event: CompactEvent) => receivedEvents.push(event);
+    const counter = (_messages: Message[]): number => 100;
+
+    const mgr = new ContextWindowManager(1000, counter, null, null, null, onCompact);
+    mgr.setCompactionRatio(0.5);
+
+    const messages = [{ role: Role.USER, content: "short" }];
+
+    mgr.compact(messages);
+
+    expect(receivedEvents.length).toBe(1);
+    expect(receivedEvents[0].phase_reached).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Emit a `CompactEvent` interface whenever compaction fires in the TypeScript middleware.

## Changes

- Add `CompactEvent` interface with:
  - step_index, tokens_before/after, budget_tokens, messages_before/after
  - phase_reached (0-3), strategy_name
- Add `onCompact` callback parameter to `ContextWindowManager` constructor
- Add `lastPhase` field to `TieredCompact` to track compaction phase
- Emit `CompactEvent` in `compact()` with accurate token/message counts
- Add unit tests for callback firing and event data

Closes #39