### PR TITLE
[Go] Wire guardrails into middleware inference loop

### DIFF
--- a/go/middleware/inference/inference.go
+++ b/go/middleware/inference/inference.go
@@ -1,0 +1,183 @@
+package inference
+
+import (
+	"context"
+	"errors"
+
+	"github.com/soypete/pedro-agentware/go/llm"
+	"github.com/soypete/pedro-agentware/go/middleware/guardrails"
+)
+
+var ErrRetriesExhausted = errors.New("retries exhausted")
+
+type InferenceResult struct {
+	Response        llm.Response
+	NewMessages     []llm.Message
+	ToolCallCounter int
+	Attempts        int
+}
+
+type InferenceConfig struct {
+	Client         llm.Backend
+	ContextManager *llm.ContextWindowManager
+	Validator      *guardrails.ResponseValidator
+	ErrorTracker   *guardrails.ErrorTracker
+	StepEnforcer   *guardrails.StepEnforcer
+	ToolSpecs      []llm.ToolDefinition
+	MaxAttempts    int
+	StepIndex      int
+}
+
+func RunInference(ctx context.Context, messages []llm.Message, cfg InferenceConfig) (*InferenceResult, error) {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 3
+	}
+
+	currentMessages := make([]llm.Message, len(messages))
+	copy(currentMessages, messages)
+
+	var lastResponse llm.Response
+	var toolCallCounter int
+
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		if cfg.ContextManager != nil {
+			if cfg.ContextManager.ShouldCompact(currentMessages) {
+				compacted, err := cfg.ContextManager.Compact(currentMessages)
+				if err != nil {
+					return nil, err
+				}
+				currentMessages = compacted
+			}
+
+			warning := cfg.ContextManager.CheckThresholds(ctx, currentMessages)
+			if warning != "" {
+				warningMsg := llm.Message{
+					Role:    llm.RoleUser,
+					Content: warning,
+					Meta: llm.MessageMeta{
+						Type: llm.MessageTypeContextWarning,
+					},
+				}
+				currentMessages = append(currentMessages, warningMsg)
+			}
+		}
+
+		req := &llm.Request{
+			Messages:    currentMessages,
+			Tools:       cfg.ToolSpecs,
+			Temperature: 0.7,
+			MaxTokens:   4096,
+		}
+
+		resp, err := cfg.Client.Complete(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		if cfg.ContextManager != nil && resp.UsageTokens.TotalTokens > 0 {
+			cfg.ContextManager.UpdateTokenCount(resp.UsageTokens.TotalTokens)
+		}
+
+		var validationResult guardrails.ValidationResult
+
+		if len(resp.ToolCalls) > 0 {
+			toolCalls := make([]guardrails.ToolCall, len(resp.ToolCalls))
+			for i, tc := range resp.ToolCalls {
+				toolCalls[i] = guardrails.ToolCall{
+					Tool: tc.Name,
+					Args: tc.Args,
+				}
+			}
+			validationResult = cfg.Validator.ValidateToolCalls(toolCalls)
+		} else if resp.Content != "" {
+			validationResult = cfg.Validator.ValidateTextResponse(resp.Content)
+			if !validationResult.NeedsRetry && len(validationResult.ToolCalls) > 0 {
+				resp.ToolCalls = make([]llm.ToolCall, len(validationResult.ToolCalls))
+				for i, tc := range validationResult.ToolCalls {
+					resp.ToolCalls[i] = llm.ToolCall{
+						ID:   "",
+						Name: tc.Tool,
+						Args: tc.Args,
+					}
+				}
+			}
+		} else {
+			validationResult = guardrails.ValidationResult{
+				ToolCalls:  nil,
+				Nudge:      guardrails.RetryNudge("empty response", getToolNames(cfg.ToolSpecs)),
+				NeedsRetry: true,
+			}
+		}
+
+		lastResponse = *resp
+
+		if !validationResult.NeedsRetry {
+			if cfg.ErrorTracker != nil {
+				cfg.ErrorTracker.ResetSession("")
+			}
+
+			if cfg.StepEnforcer != nil && len(resp.ToolCalls) > 0 {
+				for _, tc := range resp.ToolCalls {
+					allowed, missing := cfg.StepEnforcer.CanExecute("", tc.Name)
+					if !allowed {
+						nudge := guardrails.StepNudge(tc.Name, missing, 1)
+						currentMessages = append(currentMessages, llm.Message{
+							Role:    llm.RoleUser,
+							Content: nudge.Content,
+							Meta: llm.MessageMeta{
+								Type: llm.MessageTypeStepNudge,
+							},
+						})
+						continue
+					}
+				}
+			}
+
+			toolCallCounter += len(resp.ToolCalls)
+			return &InferenceResult{
+				Response:        lastResponse,
+				NewMessages:     currentMessages,
+				ToolCallCounter: toolCallCounter,
+				Attempts:        attempt,
+			}, nil
+		}
+
+		if cfg.ErrorTracker != nil {
+			cfg.ErrorTracker.RecordError("", "", nil, errors.New("validation failed"), guardrails.ErrCategoryUnknown)
+		}
+
+		if attempt >= cfg.MaxAttempts {
+			return nil, ErrRetriesExhausted
+		}
+
+		if validationResult.Nudge != nil {
+			nudgeMsg := llm.Message{
+				Role:    llm.RoleUser,
+				Content: validationResult.Nudge.Content,
+				Meta: llm.MessageMeta{
+					Type: llm.MessageTypeRetryNudge,
+				},
+			}
+			currentMessages = append(currentMessages, nudgeMsg)
+		}
+
+		failedMsg := llm.Message{
+			Role:    llm.RoleAssistant,
+			Content: resp.Content,
+			Meta: llm.MessageMeta{
+				Type: llm.MessageTypeTextResponse,
+			},
+		}
+		currentMessages = append(currentMessages, failedMsg)
+	}
+
+	return nil, ErrRetriesExhausted
+}
+
+func getToolNames(specs []llm.ToolDefinition) []string {
+	names := make([]string, len(specs))
+	for i, spec := range specs {
+		names[i] = spec.Name
+	}
+	return names
+}

--- a/go/middleware/inference/inference_test.go
+++ b/go/middleware/inference/inference_test.go
@@ -1,0 +1,243 @@
+package inference
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/soypete/pedro-agentware/go/llm"
+	"github.com/soypete/pedro-agentware/go/middleware/guardrails"
+)
+
+type mockBackend struct {
+	resp         *llm.Response
+	respOnRetry  *llm.Response
+	callCount    int
+	err          error
+	returnOnCall int
+}
+
+func (m *mockBackend) Complete(ctx context.Context, req *llm.Request) (*llm.Response, error) {
+	m.callCount++
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.respOnRetry != nil && m.callCount > 1 {
+		return m.respOnRetry, nil
+	}
+	return m.resp, nil
+}
+
+func (m *mockBackend) SupportsNativeToolCalling() bool {
+	return true
+}
+
+func (m *mockBackend) ModelName() string {
+	return "test-model"
+}
+
+func (m *mockBackend) ContextWindowSize() int {
+	return 8192
+}
+
+func TestRunInference_Success(t *testing.T) {
+	backend := &mockBackend{
+		resp: &llm.Response{
+			Content:      "",
+			ToolCalls:    []llm.ToolCall{{ID: "1", Name: "test_tool", Args: map[string]any{"key": "value"}}},
+			FinishReason: "tool_calls",
+			UsageTokens:  llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+		},
+	}
+
+	validator := guardrails.NewResponseValidator([]string{"test_tool"}, false)
+	tracker := guardrails.NewErrorTracker()
+
+	cfg := InferenceConfig{
+		Client:       backend,
+		Validator:    validator,
+		ErrorTracker: tracker,
+		ToolSpecs:    []llm.ToolDefinition{{Name: "test_tool", Description: "A test tool", InputSchema: map[string]any{}}},
+		MaxAttempts:  3,
+		StepIndex:    0,
+	}
+
+	messages := []llm.Message{
+		{Role: llm.RoleUser, Content: "Hello", Meta: llm.MessageMeta{Type: llm.MessageTypeUserInput}},
+	}
+
+	result, err := RunInference(context.Background(), messages, cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Attempts != 1 {
+		t.Errorf("expected 1 attempt, got %d", result.Attempts)
+	}
+
+	if len(result.Response.ToolCalls) != 1 {
+		t.Errorf("expected 1 tool call, got %d", len(result.Response.ToolCalls))
+	}
+
+	if backend.callCount != 1 {
+		t.Errorf("expected backend called once, got %d", backend.callCount)
+	}
+}
+
+func TestRunInference_Retry_NeedsRetry(t *testing.T) {
+	backend := &mockBackend{
+		resp: &llm.Response{
+			Content:      "This is just text, not a tool call",
+			ToolCalls:    nil,
+			FinishReason: "stop",
+			UsageTokens:  llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+		},
+		respOnRetry: &llm.Response{
+			Content:      "",
+			ToolCalls:    []llm.ToolCall{{ID: "1", Name: "test_tool", Args: map[string]any{"key": "value"}}},
+			FinishReason: "tool_calls",
+			UsageTokens:  llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+		},
+	}
+
+	validator := guardrails.NewResponseValidator([]string{"test_tool"}, false)
+	tracker := guardrails.NewErrorTracker()
+
+	cfg := InferenceConfig{
+		Client:       backend,
+		Validator:    validator,
+		ErrorTracker: tracker,
+		ToolSpecs:    []llm.ToolDefinition{{Name: "test_tool", Description: "A test tool", InputSchema: map[string]any{}}},
+		MaxAttempts:  3,
+		StepIndex:    0,
+	}
+
+	messages := []llm.Message{
+		{Role: llm.RoleUser, Content: "Hello", Meta: llm.MessageMeta{Type: llm.MessageTypeUserInput}},
+	}
+
+	result, err := RunInference(context.Background(), messages, cfg)
+	if err != nil {
+		t.Fatalf("expected no error on retry, got %v", err)
+	}
+
+	if backend.callCount != 2 {
+		t.Errorf("expected 2 backend calls (original + retry), got %d", backend.callCount)
+	}
+
+	if len(result.NewMessages) <= len(messages) {
+		t.Errorf("expected messages to be appended with nudge, got %d messages", len(result.NewMessages))
+	}
+}
+
+func TestRunInference_RetriesExhausted(t *testing.T) {
+	backend := &mockBackend{
+		resp: &llm.Response{
+			Content:      "This is just text, not a tool call",
+			ToolCalls:    nil,
+			FinishReason: "stop",
+			UsageTokens:  llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+		},
+	}
+
+	validator := guardrails.NewResponseValidator([]string{"test_tool"}, false)
+	tracker := guardrails.NewErrorTracker()
+
+	cfg := InferenceConfig{
+		Client:       backend,
+		Validator:    validator,
+		ErrorTracker: tracker,
+		ToolSpecs:    []llm.ToolDefinition{{Name: "test_tool", Description: "A test tool", InputSchema: map[string]any{}}},
+		MaxAttempts:  2,
+		StepIndex:    0,
+	}
+
+	messages := []llm.Message{
+		{Role: llm.RoleUser, Content: "Hello", Meta: llm.MessageMeta{Type: llm.MessageTypeUserInput}},
+	}
+
+	_, err := RunInference(context.Background(), messages, cfg)
+	if !errors.Is(err, ErrRetriesExhausted) {
+		t.Errorf("expected ErrRetriesExhausted, got %v", err)
+	}
+
+	if backend.callCount != 2 {
+		t.Errorf("expected 2 backend calls before exhaustion, got %d", backend.callCount)
+	}
+}
+
+func TestRunInference_Rescue(t *testing.T) {
+	backend := &mockBackend{
+		resp: &llm.Response{
+			Content:      "{\"tool\": \"test_tool\", \"args\": {\"key\": \"value\"}}",
+			ToolCalls:    nil,
+			FinishReason: "stop",
+			UsageTokens:  llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+		},
+	}
+
+	validator := guardrails.NewResponseValidator([]string{"test_tool"}, true)
+	tracker := guardrails.NewErrorTracker()
+
+	cfg := InferenceConfig{
+		Client:       backend,
+		Validator:    validator,
+		ErrorTracker: tracker,
+		ToolSpecs:    []llm.ToolDefinition{{Name: "test_tool", Description: "A test tool", InputSchema: map[string]any{}}},
+		MaxAttempts:  3,
+		StepIndex:    0,
+	}
+
+	messages := []llm.Message{
+		{Role: llm.RoleUser, Content: "Hello", Meta: llm.MessageMeta{Type: llm.MessageTypeUserInput}},
+	}
+
+	result, err := RunInference(context.Background(), messages, cfg)
+	if err != nil {
+		t.Fatalf("expected no error with rescue, got %v", err)
+	}
+
+	if len(result.Response.ToolCalls) == 0 {
+		t.Error("expected rescued tool calls")
+	}
+
+	if backend.callCount != 1 {
+		t.Errorf("expected 1 backend call (rescue succeeded), got %d", backend.callCount)
+	}
+}
+
+func TestRunInference_DefaultMaxAttempts(t *testing.T) {
+	backend := &mockBackend{
+		resp: &llm.Response{
+			Content:      "This is just text, not a tool call",
+			ToolCalls:    nil,
+			FinishReason: "stop",
+			UsageTokens:  llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+		},
+	}
+
+	validator := guardrails.NewResponseValidator([]string{"test_tool"}, false)
+	tracker := guardrails.NewErrorTracker()
+
+	cfg := InferenceConfig{
+		Client:       backend,
+		Validator:    validator,
+		ErrorTracker: tracker,
+		ToolSpecs:    []llm.ToolDefinition{{Name: "test_tool", Description: "A test tool", InputSchema: map[string]any{}}},
+		MaxAttempts:  0,
+		StepIndex:    0,
+	}
+
+	messages := []llm.Message{
+		{Role: llm.RoleUser, Content: "Hello", Meta: llm.MessageMeta{Type: llm.MessageTypeUserInput}},
+	}
+
+	_, err := RunInference(context.Background(), messages, cfg)
+	if !errors.Is(err, ErrRetriesExhausted) {
+		t.Errorf("expected ErrRetriesExhausted with default max attempts, got %v", err)
+	}
+
+	if backend.callCount != 3 {
+		t.Errorf("expected 3 backend calls with default max attempts (3), got %d", backend.callCount)
+	}
+}

--- a/go/middleware/inference/inference_test.go
+++ b/go/middleware/inference/inference_test.go
@@ -10,11 +10,10 @@ import (
 )
 
 type mockBackend struct {
-	resp         *llm.Response
-	respOnRetry  *llm.Response
-	callCount    int
-	err          error
-	returnOnCall int
+	resp        *llm.Response
+	respOnRetry *llm.Response
+	callCount   int
+	err         error
 }
 
 func (m *mockBackend) Complete(ctx context.Context, req *llm.Request) (*llm.Response, error) {


### PR DESCRIPTION
Implements issue #46 - Creates a shared RunInference function that wires together all guardrail components into a unified inference loop.

Changes:
- Added middleware/inference/inference.go with InferenceConfig, InferenceResult, and RunInference function
- Added inference_test.go with tests for success, retry, exhaustion, rescue, and default max attempts

The RunInference function handles:
- Context window compaction
- Threshold warning injection
- LLM API calls
- Response validation and rescue
- Error tracking and retry budget
- Step enforcement after tool calls

Closes #46