### PR TITLE
feat(typescript): implement runInference with guardrails integration (issue #47)

### DIFF
--- a/typescript/src/middleware/inference.ts
+++ b/typescript/src/middleware/inference.ts
@@ -34,10 +34,6 @@ export interface InferenceConfig {
   stepIndex?: number;
 }
 
-function getToolNames(specs: ToolDefinition[]): string[] {
-  return specs.map((spec) => spec.name);
-}
-
 export async function runInference(
   messages: Message[],
   cfg: InferenceConfig,

--- a/typescript/src/middleware/inference.ts
+++ b/typescript/src/middleware/inference.ts
@@ -1,0 +1,197 @@
+import type { Message, ToolDefinition } from "../llm/request.js";
+import type { Response, ToolCall as LlmToolCall } from "../llm/response.js";
+import type { Backend } from "../llm/backend.js";
+import type { ContextWindowManager } from "../llmcontext/context_window.js";
+import { Role } from "../llm/request.js";
+import { MessageType } from "./types.js";
+import type { ResponseValidator, ToolCall, ValidationResult } from "./guardrails/response_validator.js";
+import { ErrorTracker, ErrorCategory } from "./guardrails/error_tracker.js";
+import { StepEnforcer } from "./guardrails/step_enforcer.js";
+import { stepNudge } from "./guardrails/nudge.js";
+
+export class RetriesExhaustedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RetriesExhaustedError";
+  }
+}
+
+export interface InferenceResult {
+  response: Response;
+  newMessages: Message[];
+  toolCallCounter: number;
+  attempts: number;
+}
+
+export interface InferenceConfig {
+  client: Backend;
+  contextManager?: ContextWindowManager;
+  validator?: ResponseValidator;
+  errorTracker?: ErrorTracker;
+  stepEnforcer?: StepEnforcer;
+  toolSpecs: ToolDefinition[];
+  maxAttempts: number;
+  stepIndex?: number;
+}
+
+function getToolNames(specs: ToolDefinition[]): string[] {
+  return specs.map((spec) => spec.name);
+}
+
+export async function runInference(
+  messages: Message[],
+  cfg: InferenceConfig,
+  sessionId: string = ""
+): Promise<InferenceResult | null> {
+  let maxAttempts = cfg.maxAttempts;
+  if (maxAttempts <= 0) {
+    maxAttempts = 3;
+  }
+
+  const currentMessages: Message[] = [...messages];
+
+  let lastResponse: Response | null = null;
+  let toolCallCounter = 0;
+  let attempts = 0;
+
+  while (attempts < maxAttempts) {
+    attempts++;
+
+    if (cfg.contextManager) {
+      if (cfg.contextManager.shouldCompact(currentMessages)) {
+        const compacted = cfg.contextManager.compact(currentMessages);
+        currentMessages.length = 0;
+        currentMessages.push(...compacted);
+      }
+
+      const warning = cfg.contextManager.checkThresholds(currentMessages);
+      if (warning) {
+        const warningMsg: Message = {
+          role: Role.USER,
+          content: warning,
+          meta: { type: MessageType.CONTEXT_WARNING },
+        };
+        currentMessages.push(warningMsg);
+      }
+    }
+
+    let resp: Response;
+    try {
+      resp = cfg.client.complete(currentMessages);
+    } catch (e) {
+      if (cfg.errorTracker && e instanceof Error) {
+        cfg.errorTracker.recordError(sessionId, "", {}, e, ErrorCategory.UNKNOWN);
+      }
+      throw e;
+    }
+
+    if (cfg.contextManager && resp.usage_tokens.total_tokens > 0) {
+      cfg.contextManager.updateTokenCount(resp.usage_tokens.total_tokens);
+    }
+
+    let validationResult: ValidationResult | null = null;
+
+    if (resp.tool_calls && resp.tool_calls.length > 0) {
+      const guardrailsToolCalls: ToolCall[] = resp.tool_calls.map((tc) => ({
+        tool: tc.name,
+        args: tc.arguments,
+      }));
+      if (cfg.validator) {
+        validationResult = cfg.validator.validateToolCalls(guardrailsToolCalls);
+      } else {
+        validationResult = {
+          toolCalls: guardrailsToolCalls,
+          nudge: null,
+          needsRetry: false,
+        };
+      }
+    } else if (resp.content) {
+      if (cfg.validator) {
+        validationResult = cfg.validator.validateTextResponse(resp.content);
+      } else {
+        validationResult = { toolCalls: [], nudge: null, needsRetry: false };
+      }
+
+      if (!validationResult.needsRetry && validationResult.toolCalls.length > 0) {
+        resp.tool_calls = validationResult.toolCalls.map(
+          (tc) =>
+            ({
+              id: "",
+              name: tc.tool,
+              arguments: tc.args,
+            } as LlmToolCall)
+        );
+      }
+    } else {
+      if (cfg.validator) {
+        validationResult = cfg.validator.validateTextResponse("");
+      } else {
+        validationResult = { toolCalls: [], nudge: null, needsRetry: true };
+      }
+    }
+
+    lastResponse = resp;
+
+    if (validationResult && !validationResult.needsRetry) {
+      if (cfg.errorTracker) {
+        cfg.errorTracker.resetSession(sessionId);
+      }
+
+      if (cfg.stepEnforcer && resp.tool_calls && resp.tool_calls.length > 0) {
+        for (const tc of resp.tool_calls) {
+          const [allowed, missing] = cfg.stepEnforcer.canExecute(sessionId, tc.name);
+          if (!allowed) {
+            const nudge = stepNudge(tc.name, missing, 1);
+            const nudgeMsg: Message = {
+              role: Role.USER,
+              content: nudge.content,
+              meta: { type: MessageType.STEP_NUDGE },
+            };
+            currentMessages.push(nudgeMsg);
+            continue;
+          }
+        }
+      }
+
+      toolCallCounter += resp.tool_calls ? resp.tool_calls.length : 0;
+      return {
+        response: lastResponse,
+        newMessages: currentMessages,
+        toolCallCounter,
+        attempts,
+      };
+    }
+
+    if (cfg.errorTracker) {
+      cfg.errorTracker.recordError(
+        sessionId,
+        "",
+        {},
+        new Error("validation failed"),
+        ErrorCategory.UNKNOWN
+      );
+    }
+
+    if (attempts >= maxAttempts) {
+      throw new RetriesExhaustedError(`retries exhausted after ${attempts} attempts`);
+    }
+
+    if (validationResult && validationResult.nudge) {
+      const nudgeMsg: Message = {
+        role: Role.USER,
+        content: validationResult.nudge.content,
+        meta: { type: MessageType.RETRY_NUDGE },
+      };
+      currentMessages.push(nudgeMsg);
+    }
+
+    const failedMsg: Message = {
+      role: Role.ASSISTANT,
+      content: resp.content,
+      meta: { type: MessageType.TEXT_RESPONSE },
+    };
+    currentMessages.push(failedMsg);
+  }
+
+  throw new RetriesExhaustedError(`retries exhausted after ${attempts} attempts`);
+}

--- a/typescript/tests/inference.test.ts
+++ b/typescript/tests/inference.test.ts
@@ -1,0 +1,378 @@
+import type { Message, ToolDefinition } from "../src/llm/request.js";
+import { Role } from "../src/llm/request.js";
+import type { Response, ToolCall as LlmToolCall, TokenUsage } from "../src/llm/response.js";
+import { ContextWindowManager } from "../src/llmcontext/context_window.js";
+import { ResponseValidator } from "../src/middleware/guardrails/response_validator.js";
+import { ErrorTracker } from "../src/middleware/guardrails/error_tracker.js";
+import { StepEnforcer } from "../src/middleware/guardrails/step_enforcer.js";
+import {
+  InferenceConfig,
+  RetriesExhaustedError,
+  runInference,
+} from "../src/middleware/inference.js";
+
+interface MockBackend {
+  complete(messages: Message[]): Response;
+  supportsNativeToolCalling(): boolean;
+  modelName(): string;
+  contextWindowSize(): number;
+}
+
+function createMockResponse(
+  content: string,
+  toolCalls: LlmToolCall[] = [],
+  usageTokens?: TokenUsage
+): Response {
+  return {
+    content,
+    tool_calls: toolCalls,
+    finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop",
+    usage_tokens: usageTokens ?? {
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    },
+  };
+}
+
+function createToolDefinition(name: string): ToolDefinition {
+  return {
+    name,
+    description: `A ${name} tool`,
+    input_schema: { type: "object", properties: {} },
+  };
+}
+
+describe("runInference", () => {
+  let mockResponses: Response[];
+  let callCount: number;
+
+  beforeEach(() => {
+    callCount = 0;
+    mockResponses = [];
+  });
+
+  const createMockBackend = (): MockBackend => ({
+    complete: (messages: Message[]): Response => {
+      if (callCount >= mockResponses.length) {
+        return mockResponses[mockResponses.length - 1];
+      }
+      const resp = mockResponses[callCount];
+      callCount++;
+      return resp;
+    },
+    supportsNativeToolCalling: () => true,
+    modelName: () => "mock",
+    contextWindowSize: () => 8192,
+  });
+
+  it("should return inference result on successful tool call", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("", [
+        { id: "1", name: "test_tool", arguments: {} },
+      ]),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg);
+
+    expect(result).not.toBeNull();
+    expect(result!.response.tool_calls).toHaveLength(1);
+    expect(result!.response.tool_calls[0].name).toBe("test_tool");
+    expect(result!.attempts).toBe(1);
+  });
+
+  it("should rescue text response into tool calls", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse('{"tool": "test_tool", "args": {"key": "value"}}', []),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], true);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg);
+
+    expect(result).not.toBeNull();
+    expect(result!.response.tool_calls).toHaveLength(1);
+  });
+
+  it("should retry on invalid response", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("This is just text, not a tool call", []),
+      createMockResponse("", [{ id: "1", name: "test_tool", arguments: {} }]),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg);
+
+    expect(result).not.toBeNull();
+    expect(result!.attempts).toBe(2);
+  });
+
+  it("should throw RetriesExhaustedError when max attempts exceeded", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("This is just text", []),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 2,
+      stepIndex: 0,
+    };
+
+    await expect(runInference(messages, cfg)).rejects.toThrow(RetriesExhaustedError);
+  });
+
+  it("should trigger context compaction when needed", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("", [{ id: "1", name: "test_tool", arguments: {} }]),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+    
+    const mockCtxManager = {
+      shouldCompact: () => true,
+      compact: (msgs: Message[]) => [msgs[0]],
+      addWarning: () => {},
+      checkThresholds: () => undefined,
+      updateTokenCount: () => {},
+    } as unknown as ContextWindowManager;
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      contextManager: mockCtxManager,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg);
+    expect(result).not.toBeNull();
+  });
+
+  it("should inject context threshold warnings", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("", [{ id: "1", name: "test_tool", arguments: {} }], {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 8000,
+      }),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+    const ctxManager = new ContextWindowManager(10000);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      contextManager: ctxManager,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg);
+    expect(result).not.toBeNull();
+  });
+
+  it("should use error tracker on validation failures", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("This is just text", []),
+      createMockResponse("", [{ id: "1", name: "test_tool", arguments: {} }]),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+    const errorTracker = new ErrorTracker(5);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      errorTracker,
+      maxAttempts: 5,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg, "test-session");
+    expect(result).not.toBeNull();
+  });
+
+  it("should check step enforcer for tool prerequisites", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("final_tool");
+
+    mockResponses = [
+      createMockResponse("", [{ id: "1", name: "final_tool", arguments: {} }]),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["final_tool", "step1"], false);
+    const stepEnforcer = new StepEnforcer();
+    stepEnforcer.addStep("final_tool", ["step1"]);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      stepEnforcer,
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg, "test-session");
+    expect(result).not.toBeNull();
+  });
+
+  it("should retry on empty response", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("", []),
+      createMockResponse("", [{ id: "1", name: "test_tool", arguments: {} }]),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg);
+
+    expect(result).not.toBeNull();
+    expect(result!.attempts).toBe(2);
+  });
+
+  it("should respect max attempts from config", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("This is just text", []),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 5,
+      stepIndex: 0,
+    };
+
+    await expect(runInference(messages, cfg)).rejects.toThrow(
+      "retries exhausted after 5 attempts"
+    );
+  });
+
+  it("should use default max attempts when zero", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("This is just text", []),
+    ];
+
+    const backend = createMockBackend();
+    const validator = new ResponseValidator(["test_tool"], false);
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      validator,
+      maxAttempts: 0,
+      stepIndex: 0,
+    };
+
+    await expect(runInference(messages, cfg)).rejects.toThrow(RetriesExhaustedError);
+  });
+
+  it("should work without optional guardrail components", async () => {
+    const messages: Message[] = [{ role: Role.USER, content: "test" }];
+    const toolDef = createToolDefinition("test_tool");
+
+    mockResponses = [
+      createMockResponse("", [{ id: "1", name: "test_tool", arguments: {} }]),
+    ];
+
+    const backend = createMockBackend();
+
+    const cfg: InferenceConfig = {
+      client: backend,
+      toolSpecs: [toolDef],
+      maxAttempts: 3,
+      stepIndex: 0,
+    };
+
+    const result = await runInference(messages, cfg);
+
+    expect(result).not.toBeNull();
+    expect(result!.attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the TypeScript version of  that wires guardrails into the middleware inference loop, mirroring the Go and Python implementations.

## Changes

- Added  with  function
- Added  with 12 passing tests

## Features

- Retry logic with configurable max attempts
- Context compaction support via ContextWindowManager
- Token threshold warnings injection
- Response validation with tool call extraction
- Error tracking integration
- Step enforcer for tool prerequisites
- Optional guardrail components for partial usage

## Testing

All 12 tests pass:
- Successful tool call
- Text rescue into tool calls
- Retry on invalid response
- Max attempts exceeded error
- Context compaction triggering
- Context threshold warnings
- Error tracker integration
- Step enforcer prerequisites
- Empty response retry
- Configurable max attempts
- Default attempts fallback
- Works without optional components

Closes #47