### PR TITLE
Add Hermes agent adapter for pedro-agentware

### DIFF
--- a/docs/kitaru/go/README.md
+++ b/docs/kitaru/go/README.md
@@ -1,0 +1,98 @@
+# Kitaru Go SDK Integration
+
+Documentation for using the Kitaru Go SDK (`kitaru-go`) with pedro-agentware middleware.
+
+## Overview
+
+Kitaru is a durable execution runtime for AI agents. This guide covers integrating the Go SDK (`kitaru-go`) with pedro-agentware when Kitaru is deployed in Kubernetes.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Kubernetes Cluster                           │
+│                                                                 │
+│  ┌─────────────────┐     ┌───────────────────────────────┐    │
+│  │  Kitaru Server  │     │   pedro-agentware Middleware  │    │
+│  │   (Deployment)  │     │      (Deployment/Sidecar)     │    │
+│  │                 │◄────│                               │    │
+│  │   Port: 8080    │     │   Policy Enforcement          │    │
+│  │   /api/v1/*     │     │   - Rate limiting             │    │
+│  └────────┬────────┘     │   - Tool filtering            │    │
+│           │              │   - Audit logging             │    │
+│           ▼              └───────────────┬───────────────┘    │
+│  ┌─────────────────┐                     │                     │
+│  │   Go Client     │◄────────────────────┘                     │
+│  │  (kitaru-go)    │                                           │
+│  │                 │     ┌───────────────────────────────┐    │
+│  └─────────────────┘     │   Your Agent Application      │    │
+│                          │   - Uses kitaru-go SDK        │    │
+│                          │   - Calls middleware          │    │
+│                          └───────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Contents
+
+- [Installation](./installation.md) - Installing kitaru-go SDK
+- [Connecting to K8s](./connecting.md) - Configuring K8s-deployed Kitaru
+- [Basic Usage](./basic-usage.md) - Core flow, checkpoint, artifact operations
+- [Middleware Integration](./middleware-integration.md) - pedro-agentware integration
+  - [Policy Enforcement](./middleware-integration.md#direction-1-middleware-wraps-kitaru-tool-calls) - Middleware wraps Kitaru
+  - [Kitaru as Tools](./middleware-integration.md#direction-2-kitaru-flows-as-middleware-tools) - Kitaru flows exposed as tools
+  - [Bidirectional](./middleware-integration.md#bidirectional-integration) - Full bidirectional integration
+- [Examples](./examples/) - Code examples
+  - [Simple Flow](./examples/simple-flow.md) - Basic flow execution
+  - [Policy-Enforced Agent](./examples/policy-enforced.md) - Middleware + Kitaru integration
+- [Troubleshooting](./troubleshooting.md) - Common issues and solutions
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+)
+
+func main() {
+    // Connect to K8s-deployed Kitaru
+    client := kitaru.NewClient(
+        "http://kitaru-service.namespace.svc.cluster.local:8080",
+        "your-api-key",
+        "your-project",
+    )
+
+    ctx := context.Background()
+
+    // Run a flow
+    flow := client.Flow("my-agent-flow")
+    execID, err := flow.Run(ctx, map[string]any{
+        "task": "process user request",
+    })
+    if err != nil {
+        log.Fatalf("Failed to start flow: %v", err)
+    }
+
+    fmt.Printf("Flow started: %s\n", execID)
+
+    // Save checkpoint
+    flow.Checkpoint("analysis_complete", map[string]any{
+        "files_processed": 10,
+    })
+
+    // Check execution status
+    exec, _ := flow.GetExecution()
+    fmt.Printf("Status: %s\n", exec.Status)
+}
+```
+
+## Prerequisites
+
+- Go 1.21+
+- Access to a Kitaru deployment in Kubernetes
+- pedro-agentware middleware (optional, for policy enforcement)

--- a/docs/kitaru/go/basic-usage.md
+++ b/docs/kitaru/go/basic-usage.md
@@ -1,0 +1,293 @@
+# Basic Usage
+
+This guide covers core Kitaru Go SDK operations: flows, checkpoints, artifacts, and logging.
+
+## Creating a Client
+
+```go
+import kitaru "github.com/zenml-io/kitaru-sdk-go"
+
+// From environment variables
+client := kitaru.MustNewClientFromEnv()
+
+// Or explicit configuration
+client := kitaru.NewClient(
+    "http://kitaru-service:8080",
+    "your-api-key",
+    "your-project",
+)
+```
+
+## Running Flows
+
+### Basic Flow Execution
+
+```go
+ctx := context.Background()
+
+// Create a flow reference
+flow := client.Flow("my-agent-flow")
+
+// Run with inputs
+execID, err := flow.Run(ctx, map[string]any{
+    "task":        "analyze user request",
+    "user_id":     "user-123",
+    "session_id":  "session-456",
+})
+if err != nil {
+    log.Fatalf("Failed to start flow: %v", err)
+}
+
+fmt.Printf("Execution started: %s\n", execID)
+```
+
+### Running with Wait
+
+For flows that complete quickly, use `RunWithWait`:
+
+```go
+flow := client.Flow("quick-flow")
+exec, err := flow.RunWithWait(ctx, map[string]any{
+    "input": "data",
+}, 2 * time.Second)  // Poll interval
+if err != nil {
+    log.Fatalf("Flow failed: %v", err)
+}
+
+fmt.Printf("Status: %s, Output: %v\n", exec.Status, exec.Output)
+```
+
+## Checkpoints
+
+Checkpoints persist state and enable replay from failure points.
+
+### Saving Checkpoints
+
+```go
+// After completing a step, save a checkpoint
+err := flow.Checkpoint("analysis_complete", map[string]any{
+    "files_analyzed":  10,
+    "summary":         "Analyzed codebase structure",
+    "duration_ms":     1500,
+})
+if err != nil {
+    log.Printf("Warning: Failed to save checkpoint: %v", err)
+}
+```
+
+### Restoring Checkpoints
+
+```go
+// Restore previous checkpoint data
+checkpointData, err := flow.RestoreCheckpoint("analysis_complete")
+if err != nil {
+    log.Printf("Warning: Failed to restore checkpoint: %v", err)
+} else {
+    filesAnalyzed := checkpointData["files_analyzed"].(int)
+    fmt.Printf("Restored: %d files analyzed\n", filesAnalyzed)
+}
+```
+
+### Replay from Checkpoint
+
+If a flow fails, replay from a checkpoint:
+
+```go
+exec, err := flow.GetExecution()
+if err != nil {
+    log.Fatalf("Failed to get execution: %v", err)
+}
+
+if exec.Status == kitaru.StatusFailed {
+    // Replay from the last successful checkpoint
+    newExecID, err := flow.Replay("analysis_complete", map[string]any{
+        "input": "new data",  // Optional: override inputs
+    })
+    if err != nil {
+        log.Printf("Failed to replay: %v", err)
+    } else {
+        fmt.Printf("Replayed from checkpoint, new execution: %s\n", newExecID)
+    }
+}
+```
+
+## Artifacts
+
+Store and retrieve persistent data across executions.
+
+### Saving Artifacts
+
+```go
+// Save any serializable data
+err := flow.SaveArtifact("analysis_report", map[string]any{
+    "title":       "Code Analysis",
+    "findings":    []string{"issue-1", "issue-2"},
+    "severity":    "medium",
+}, "application/json")
+if err != nil {
+    log.Printf("Warning: Failed to save artifact: %v", err)
+}
+```
+
+### Loading Artifacts
+
+```go
+// Load artifact into struct
+var report struct {
+    Title     string   `json:"title"`
+    Findings  []string `json:"findings"`
+    Severity  string   `json:"severity"`
+}
+
+err := flow.LoadArtifact("analysis_report", &report)
+if err != nil {
+    log.Printf("Warning: Failed to load artifact: %v", err)
+} else {
+    fmt.Printf("Report: %s (%s)\n", report.Title, report.Severity)
+}
+```
+
+## Logging
+
+Add structured logs for observability.
+
+```go
+// Info level
+err := flow.Log(kitaru.LogLevelInfo, "Completed analysis phase", map[string]any{
+    "phase":       "analysis",
+    "duration_ms": 1500,
+})
+
+// Debug level
+err := flow.Log(kitaru.LogLevelDebug, "Processing file", map[string]any{
+    "file":  "main.go",
+    "lines": 150,
+})
+
+// Error level
+err := flow.Log(kitaru.LogLevelError, "API call failed", map[string]any{
+    "endpoint": "/api/analyze",
+    "status":   500,
+})
+```
+
+## Execution Management
+
+### Get Execution Status
+
+```go
+exec, err := flow.GetExecution()
+if err != nil {
+    log.Fatalf("Failed to get execution: %v", err)
+}
+
+fmt.Printf("Status: %s\n", exec.Status)
+fmt.Printf("Started: %s\n", exec.StartedAt)
+fmt.Printf("Updated: %s\n", exec.UpdatedAt)
+fmt.Printf("Output: %v\n", exec.Output)
+```
+
+### Execution States
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Flow queued, not started |
+| `running` | Currently executing |
+| `waiting` | Paused (e.g., human input) |
+| `completed` | Successfully finished |
+| `failed` | Failed with error |
+
+### Wait for Completion
+
+```go
+// Poll for completion
+exec, err := flow.RunWithWait(ctx, inputs, 2*time.Second)
+if err != nil {
+    // Handle error
+}
+
+// Or manual polling
+execID, _ := flow.Run(ctx, inputs)
+for {
+    exec, _ := flow.GetExecution()
+    if exec.Status == kitaru.StatusCompleted || exec.Status == kitaru.StatusFailed {
+        break
+    }
+    time.Sleep(2 * time.Second)
+}
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+)
+
+func main() {
+    client := kitaru.MustNewClientFromEnv()
+    ctx := context.Background()
+
+    flow := client.Flow("data-processing-agent")
+
+    // Run flow
+    execID, err := flow.Run(ctx, map[string]any{
+        "input_file": "data.csv",
+    })
+    if err != nil {
+        log.Fatalf("Failed to start flow: %v", err)
+    }
+    fmt.Printf("Started: %s\n", execID)
+
+    // Checkpoint after validation
+    flow.Checkpoint("validation_done", map[string]any{
+        "rows_validated": 1000,
+        "invalid_rows":   5,
+    })
+
+    // Log progress
+    flow.Log(kitaru.LogLevelInfo, "Processing records", map[string]any{
+        "processed": 500,
+        "total":     1000,
+    })
+
+    // Save artifact
+    flow.SaveArtifact("results", map[string]any{
+        "total_processed": 1000,
+        "success_rate":    0.995,
+    }, "application/json")
+
+    // Wait for completion
+    exec, err := flow.RunWithWait(ctx, nil, 2*time.Second)
+    if err != nil {
+        log.Fatalf("Flow failed: %v", err)
+    }
+
+    fmt.Printf("Final status: %s\n", exec.Status)
+
+    // Handle failure with replay
+    if exec.Status == kitaru.StatusFailed {
+        newID, err := flow.Replay("validation_done", nil)
+        if err != nil {
+            log.Printf("Replay failed: %v", err)
+        } else {
+            fmt.Printf("Replayed from checkpoint: %s\n", newID)
+        }
+    }
+}
+```
+
+## Best Practices
+
+1. **Save checkpoints after each major step** - Enables efficient replay on failure
+2. **Use structured metadata in logs** - Makes debugging easier
+3. **Save artifacts for important outputs** - Preserves data across executions
+4. **Set appropriate poll intervals** - 1-5 seconds is usually good
+5. **Handle errors gracefully** - Checkpoint/log failures shouldn't crash flows

--- a/docs/kitaru/go/connecting.md
+++ b/docs/kitaru/go/connecting.md
@@ -1,0 +1,262 @@
+# Connecting to Kubernetes-Deployed Kitaru
+
+This guide covers configuring the kitaru-go SDK to connect to Kitaru deployed in Kubernetes.
+
+## Kubernetes Service Discovery
+
+When Kitaru is deployed in Kubernetes, it exposes a Service. The SDK connects via:
+
+- **Internal**: `http://<service-name>.<namespace>.svc.cluster.local:<port>`
+- **Ingress**: `https://kitaru.yourdomain.com`
+- **LoadBalancer**: `http://<external-ip>:<port>`
+
+## Configuration Methods
+
+### Method 1: Environment Variables
+
+Set environment variables in your deployment:
+
+```yaml
+env:
+  - name: KITARU_URL
+    value: "http://kitaru-service.default.svc.cluster.local:8080"
+  - name: KITARU_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: kitaru-credentials
+        key: api-key
+  - name: KITARU_PROJECT
+    value: "your-project"
+```
+
+Then create the client:
+
+```go
+client := kitaru.MustNewClientFromEnv()
+```
+
+### Method 2: Explicit Configuration
+
+```go
+client := kitaru.NewClient(
+    "http://kitaru-service.default.svc.cluster.local:8080",
+    "your-api-key",
+    "your-project",
+)
+```
+
+### Method 3: Kubernetes Service Mesh
+
+If using Istio or Linkerd:
+
+```go
+client := kitaru.NewClient(
+    "http://kitaru-service.namespace.svc.cluster.local:8080",
+    "your-api-key",
+    "your-project",
+    kitaru.WithTimeout(30 * time.Second),
+    kitaru.WithRetry(3),
+)
+```
+
+## Service Discovery Examples
+
+### Standard Deployment
+
+```yaml
+# kitaru-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kitaru
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kitaru
+  template:
+    metadata:
+      labels:
+        app: kitaru
+    spec:
+      containers:
+      - name: kitaru
+        image: kitaru/server:latest
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kitaru-service
+spec:
+  selector:
+    app: kitaru
+  ports:
+  - port: 8080
+    targetPort: 8080
+  type: ClusterIP
+```
+
+Connect with:
+
+```go
+client := kitaru.NewClient(
+    "http://kitaru-service.default.svc.cluster.local:8080",
+    "api-key",
+    "project",
+)
+```
+
+### With Ingress
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kitaru-ingress
+spec:
+  rules:
+  - host: kitaru.yourcompany.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kitaru-service
+            port:
+              number: 8080
+```
+
+Connect with:
+
+```go
+client := kitaru.NewClient(
+    "https://kitaru.yourcompany.com",
+    "api-key",
+    "project",
+)
+```
+
+### With External LoadBalancer
+
+```yaml
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 203.0.113.10
+```
+
+Connect with:
+
+```go
+client := kitaru.NewClient(
+    "http://203.0.113.10:8080",
+    "api-key",
+    "project",
+)
+```
+
+## Authentication
+
+### API Key Authentication
+
+```go
+client := kitaru.NewClient(
+    "http://kitaru-service:8080",
+    "your-api-key",
+    "your-project",
+)
+```
+
+### OAuth2 (if configured)
+
+```go
+client := kitaru.NewClient(
+    "http://kitaru-service:8080",
+    "",
+    "your-project",
+    kitaru.WithOAuth2("client-id", "client-secret", "https://auth.example.com"),
+)
+```
+
+## Connection Options
+
+The SDK provides configuration options:
+
+```go
+client := kitaru.NewClient(
+    baseURL,
+    apiKey,
+    project,
+    kitaru.WithTimeout(30 * time.Second),      // Request timeout
+    kitaru.WithRetry(3),                        // Retry attempts
+    kitaru.WithDebug(true),                     // Debug logging
+)
+```
+
+## Health Check
+
+Verify connectivity:
+
+```go
+func checkConnection(client *kitaru.Client) error {
+    ctx := context.Background()
+    return client.Ping(ctx)
+}
+
+// Or check via HTTP
+func checkHealth(client *kitaru.Client) error {
+    resp, err := client.R().Get("/health")
+    if err != nil {
+        return fmt.Errorf("connection failed: %w", err)
+    }
+    if resp.StatusCode() != 200 {
+        return fmt.Errorf("unhealthy: %d", resp.StatusCode())
+    }
+    return nil
+}
+```
+
+## DNS Resolution
+
+For local development, you can use `kubectl port-forward`:
+
+```bash
+kubectl port-forward -n default svc/kitaru-service 8080:8080
+```
+
+Then connect with:
+
+```go
+client := kitaru.NewClient(
+    "http://localhost:8080",
+    "api-key",
+    "project",
+)
+```
+
+## Network Policies
+
+If using Kubernetes NetworkPolicies, ensure your pod can reach the Kitaru service:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-agent-to-kitaru
+spec:
+  podSelector:
+    matchLabels:
+      app: kitaru
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: my-agent
+    ports:
+    - protocol: TCP
+      port: 8080
+```

--- a/docs/kitaru/go/examples/policy-enforced.md
+++ b/docs/kitaru/go/examples/policy-enforced.md
@@ -1,0 +1,357 @@
+# Policy-Enforced Agent Example
+
+This example demonstrates integrating kitaru-go with pedro-agentware middleware for policy enforcement.
+
+## Overview
+
+The agent:
+1. Uses Kitaru for durable execution (checkpoints, replay on failure)
+2. Calls tools through pedro-agentware middleware
+3. Middleware enforces rate limits, denies destructive operations, and audits all calls
+
+## Project Structure
+
+```
+my-agent/
+├── main.go
+├── policy.yaml
+├── go.mod
+└── go.sum
+```
+
+## Policy Configuration (policy.yaml)
+
+```yaml
+# Policy for Kitaru agent with policy enforcement
+
+rules:
+  # Rate limit web searches
+  - name: "rate-limit-search"
+    tools:
+      - "web_search"
+    action: "allow"
+    max_rate:
+      count: 10
+      window: 60
+
+  # Rate limit data processing
+  - name: "rate-limit-process"
+    tools:
+      - "process_data"
+    action: "allow"
+    max_rate:
+      count: 5
+      window: 300
+
+  # Deny dangerous operations for untrusted callers
+  - name: "deny-destructive-untrusted"
+    tools:
+      - "delete_*"
+      - "drop_*"
+      - "truncate_*"
+    action: "deny"
+    conditions:
+      - field: "caller.trusted"
+        operator: "eq"
+        value: false
+
+  # Allow research flows for all
+  - name: "allow-research"
+    tools:
+      - "research_flow"
+      - "analyze_flow"
+    action: "allow"
+
+  # Audit all tool calls
+  - name: "audit-all"
+    tools:
+      - "*"
+    action: "allow"
+    audit: true
+
+default_deny: false
+```
+
+## Main Application (main.go)
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+    "github.com/soypete/pedro-agentware/middleware"
+    "github.com/soypete/pedro-agentware/middleware/types"
+    "github.com/soypete/pedro-agentware/middleware/audit"
+)
+
+// KitaruToolExecutor wraps Kitaru flows as middleware tools
+type KitaruToolExecutor struct {
+    client   *kitaru.Client
+    toolMap  map[string]string // tool name -> flow name
+}
+
+func NewKitaruToolExecutor(client *kitaru.Client) *KitaruToolExecutor {
+    return &KitaruToolExecutor{
+        client: client,
+        toolMap: map[string]string{
+            "research_flow":  "research-agent",
+            "analyze_flow":   "data-analyzer",
+            "process_data":   "data-processor",
+            "generate_report": "report-generator",
+        },
+    }
+}
+
+func (e *KitaruToolExecutor) CallTool(ctx context.Context, name string, args map[string]interface{}) (*types.ToolResult, error) {
+    flowName, ok := e.toolMap[name]
+    if !ok {
+        // Handle built-in tools
+        return e.callBuiltInTool(ctx, name, args)
+    }
+
+    flow := e.client.Flow(flowName)
+    exec, err := flow.RunWithWait(ctx, args, 2*time.Second)
+    if err != nil {
+        return &types.ToolResult{
+            Success: false,
+            Error:   err.Error(),
+        }, err
+    }
+
+    return &types.ToolResult{
+        Success:  exec.Status == kitaru.StatusCompleted,
+        Content:  fmt.Sprintf("%v", exec.Output),
+        Metadata: map[string]interface{}{
+            "execution_id": exec.ID,
+            "status":       exec.Status,
+        },
+    }, nil
+}
+
+func (e *KitaruToolExecutor) callBuiltInTool(ctx context.Context, name string, args map[string]interface{}) (*types.ToolResult, error) {
+    switch name {
+    case "web_search":
+        query := args["query"].(string)
+        return &types.ToolResult{
+            Success: true,
+            Content: fmt.Sprintf("Search results for: %s", query),
+            Metadata: map[string]interface{}{"query": query},
+        }, nil
+
+    case "save_file":
+        return &types.ToolResult{
+            Success: true,
+            Content: "File saved successfully",
+        }, nil
+
+    default:
+        return nil, fmt.Errorf("unknown tool: %s", name)
+    }
+}
+
+func (e *KitaruToolExecutor) ListTools() []types.ToolDefinition {
+    tools := []types.ToolDefinition{
+        // Kitaru flows
+        {Name: "research_flow", Description: "Research topic via Kitaru flow"},
+        {Name: "analyze_flow", Description: "Analyze data via Kitaru flow"},
+        {Name: "process_data", Description: "Process data via Kitaru flow"},
+        {Name: "generate_report", Description: "Generate report via Kitaru flow"},
+        // Built-in tools
+        {Name: "web_search", Description: "Search the web"},
+        {Name: "save_file", Description: "Save content to file"},
+    }
+    return tools
+}
+
+func main() {
+    // 1. Create Kitaru client
+    kitaruClient := kitaru.NewClient(
+        getEnv("KITARU_URL", "http://localhost:8080"),
+        getEnv("KITARU_API_KEY", ""),
+        getEnv("KITARU_PROJECT", "default"),
+    )
+
+    // 2. Create executor
+    executor := NewKitaruToolExecutor(kitaruClient)
+
+    // 3. Load policy
+    policy, err := middleware.LoadPolicyFromFile("policy.yaml")
+    if err != nil {
+        log.Fatalf("Failed to load policy: %v", err)
+    }
+
+    // 4. Create auditor for logging
+    auditor := audit.NewInMemoryAuditor()
+
+    // 5. Create middleware with policy and audit
+    mw := middleware.New(executor, *policy, middleware.WithAuditor(auditor))
+
+    // 6. Create caller context (e.g., from authenticated user)
+    ctx := middleware.WithCallerContext(context.Background(), types.CallerContext{
+        Trusted:   true,        // Set based on authentication
+        Role:      "user",
+        UserID:    "user-123",
+        SessionID: "session-456",
+        Source:    "api",
+    })
+
+    // 7. Run agent tasks through middleware
+    runAgentTasks(mw, ctx)
+}
+
+func runAgentTasks(mw *middleware.Middleware, ctx context.Context) {
+    // Task 1: Web search (rate limited)
+    fmt.Println("\n--- Task 1: Web Search ---")
+    for i := 0; i < 3; i++ {
+        result, err := mw.CallTool(ctx, "web_search", map[string]interface{}{
+            "query": fmt.Sprintf("Go middleware patterns #%d", i+1),
+        })
+        if err != nil {
+            log.Printf("Search %d denied: %v", i+1, err)
+        } else {
+            log.Printf("Search %d result: %s", i+1, result.Content)
+        }
+        time.Sleep(100 * time.Millisecond)
+    }
+
+    // Task 2: Run research flow through Kitaru
+    fmt.Println("\n--- Task 2: Kitaru Research Flow ---")
+    result, err := mw.CallTool(ctx, "research_flow", map[string]interface{}{
+        "topic": "agent middleware patterns",
+    })
+    if err != nil {
+        log.Printf("Research flow error: %v", err)
+    } else {
+        log.Printf("Research result: %s", result.Content)
+    }
+
+    // Task 3: Try destructive operation (should be denied for untrusted)
+    fmt.Println("\n--- Task 3: Attempt Destructive Operation ---")
+    untrustedCtx := middleware.WithCallerContext(context.Background(), types.CallerContext{
+        Trusted:   false,
+        Role:      "guest",
+        UserID:    "guest-456",
+        Source:    "public-api",
+    })
+
+    result, err = mw.CallTool(untrustedCtx, "delete_database", map[string]interface{}{
+        "confirm": true,
+    })
+    if err != nil {
+        log.Printf("Delete denied (expected): %v", err)
+    } else {
+        log.Printf("Delete result: %s", result.Content)
+    }
+
+    // 8. Print audit log
+    fmt.Println("\n--- Audit Log ---")
+    logEntries := auditor.GetLog()
+    for _, entry := range logEntries {
+        fmt.Printf("Tool: %-20s | Decision: %-6s | Rule: %s\n",
+            entry.ToolCall.ToolName,
+            entry.Decision.Action,
+            entry.Decision.Rule,
+        )
+    }
+}
+
+func getEnv(key, defaultValue string) string {
+    if value := getEnvInternal(key); value != "" {
+        return value
+    }
+    return defaultValue
+}
+
+func getEnvInternal(key string) string {
+    // Simple env getter for example
+    // In production, use os.Getenv
+    return ""
+}
+```
+
+## Running the Example
+
+```bash
+# Install dependencies
+go mod init agent-example
+go get github.com/zenml-io/kitaru-sdk-go
+go get github.com/soypete/pedro-agentware/middleware
+
+# Run
+go run main.go
+```
+
+## Expected Output
+
+```
+--- Task 1: Web Search ---
+2026/05/26 10:00:00 Search 1 result: Search results for: Go middleware patterns #1
+2026/05/26 10:00:00 Search 2 result: Search results for: Go middleware patterns #2
+2026/05/26 10:00:00 Search 3 result: Search results for: Go middleware patterns #3
+
+--- Task 2: Kitaru Research Flow ---
+2026/05/26 10:00:01 Research result: <kitaru flow output>
+
+--- Task 3: Attempt Destructive Operation ---
+2026/05/26 10:00:02 Delete denied (expected): tool call denied by rule: deny-destructive-untrusted
+
+--- Audit Log ---
+Tool: web_search         | Decision: allow  | Rule: rate-limit-search
+Tool: web_search         | Decision: allow  | Rule: rate-limit-search
+Tool: web_search         | Decision: allow  | Rule: rate-limit-search
+Tool: research_flow      | Decision: allow  | Rule: allow-research
+Tool: delete_database    | Decision: deny   | Rule: deny-destructive-untrusted
+```
+
+## Kubernetes Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-agent
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: policy-agent
+  template:
+    metadata:
+      labels:
+        app: policy-agent
+    spec:
+      containers:
+      - name: agent
+        image: your-agent:latest
+        env:
+        - name: KITARU_URL
+          value: "http://kitaru-service.default.svc.cluster.local:8080"
+        - name: KITARU_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: kitaru-credentials
+              key: api-key
+        - name: KITARU_PROJECT
+          value: "production"
+        volumeMounts:
+        - name: policy
+          mountPath: /app/policy.yaml
+          subPath: policy.yaml
+      volumes:
+      - name: policy
+        configMap:
+          name: agent-policy
+```
+
+## Key Features Demonstrated
+
+1. **Rate Limiting** - Middleware enforces per-tool rate limits
+2. **Trust-Based Access** - Different policies for trusted vs untrusted callers
+3. **Audit Logging** - All tool calls are logged for compliance
+4. **Durable Execution** - Kitaru provides checkpoint/replay on failure
+5. **Tool Abstraction** - Kitaru flows exposed seamlessly as middleware tools

--- a/docs/kitaru/go/examples/simple-flow.md
+++ b/docs/kitaru/go/examples/simple-flow.md
@@ -1,0 +1,180 @@
+# Simple Flow Example
+
+This example demonstrates basic Kitaru flow execution using the Go SDK.
+
+## Prerequisites
+
+- Go 1.21+
+- Kitaru server running (local or K8s)
+- API key and project configured
+
+## Code
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+)
+
+func main() {
+    // Create client - uses KITARU_URL, KITARU_API_KEY, KITARU_PROJECT env vars
+    client := kitaru.MustNewClientFromEnv()
+
+    ctx := context.Background()
+
+    // Create a flow reference
+    flow := client.Flow("hello-world")
+
+    // Run the flow with inputs
+    execID, err := flow.Run(ctx, map[string]any{
+        "name": "World",
+    })
+    if err != nil {
+        log.Fatalf("Failed to start flow: %v", err)
+    }
+
+    fmt.Printf("Flow started with execution ID: %s\n", execID)
+
+    // Wait for completion
+    exec, err := flow.RunWithWait(ctx, nil, 2*time.Second)
+    if err != nil {
+        log.Fatalf("Flow failed: %v", err)
+    }
+
+    fmt.Printf("Flow completed with status: %s\n", exec.Status)
+    fmt.Printf("Output: %v\n", exec.Output)
+}
+```
+
+## Expected Output
+
+```
+Flow started with execution ID: exec-abc123
+Flow completed with status: completed
+Output: map[message:Hello, World!]
+```
+
+## Environment Variables
+
+Set these before running:
+
+```bash
+export KITARU_URL="http://localhost:8080"
+export KITARU_API_KEY="your-api-key"
+export KITARU_PROJECT="your-project"
+```
+
+Or use explicit configuration:
+
+```go
+client := kitaru.NewClient(
+    "http://kitaru-service.default.svc.cluster.local:8080",
+    "your-api-key",
+    "your-project",
+)
+```
+
+## Running the Example
+
+```bash
+go run main.go
+```
+
+## With Checkpoints and Artifacts
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+)
+
+func main() {
+    client := kitaru.MustNewClientFromEnv()
+    ctx := context.Background()
+
+    flow := client.Flow("data-pipeline")
+
+    // Start flow
+    execID, _ := flow.Run(ctx, map[string]any{
+        "input_file": "data.csv",
+    })
+    fmt.Printf("Started: %s\n", execID)
+
+    // Save checkpoint after each stage
+    flow.Checkpoint("fetch_complete", map[string]any{
+        "rows_fetched": 1000,
+    })
+
+    flow.Log(kitaru.LogLevelInfo, "Processing data", map[string]any{
+        "stage": "transform",
+    })
+
+    flow.Checkpoint("transform_complete", map[string]any{
+        "rows_transformed": 1000,
+        "duration_ms":      500,
+    })
+
+    // Save final output as artifact
+    flow.SaveArtifact("results", map[string]any{
+        "total_rows":    1000,
+        "success_count": 995,
+        "error_count":   5,
+    }, "application/json")
+
+    // Wait for completion
+    exec, _ := flow.RunWithWait(ctx, nil, 2*time.Second)
+
+    fmt.Printf("Final status: %s\n", exec.Status)
+
+    // Load and display artifact
+    var results map[string]any
+    flow.LoadArtifact("results", &results)
+    fmt.Printf("Results: %v\n", results)
+}
+```
+
+## Kubernetes Deployment
+
+Deploy your application to K8s:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kitaru-client-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kitaru-client
+  template:
+    metadata:
+      labels:
+        app: kitaru-client
+    spec:
+      containers:
+      - name: app
+        image: your-app:latest
+        env:
+        - name: KITARU_URL
+          value: "http://kitaru-service.default.svc.cluster.local:8080"
+        - name: KITARU_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: kitaru-credentials
+              key: api-key
+        - name: KITARU_PROJECT
+          value: "production"
+```

--- a/docs/kitaru/go/installation.md
+++ b/docs/kitaru/go/installation.md
@@ -1,0 +1,67 @@
+# Installation
+
+## Requirements
+
+- Go 1.21 or later
+- Access to Kitaru server (local or Kubernetes)
+
+## Install SDK
+
+```bash
+go get github.com/zenml-io/kitaru-sdk-go@latest
+```
+
+Or specify a version:
+
+```bash
+go get github.com/zenml-io/kitaru-sdk-go@v0.13.1
+```
+
+## Verify Installation
+
+Create a test file to verify the SDK installs correctly:
+
+```go
+package main
+
+import (
+    "fmt"
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+)
+
+func main() {
+    fmt.Printf("Kitaru SDK Version: %s\n", kitaru.Version)
+}
+```
+
+Run it:
+
+```bash
+go run your-test-file.go
+```
+
+## Project Setup
+
+Initialize a new Go module if you don't have one:
+
+```bash
+go mod init your-project-name
+go mod tidy
+```
+
+## Dependencies
+
+The SDK depends on:
+
+- `github.com/google/uuid` - For execution ID handling
+- `github.com/go-resty/resty/v2` - For HTTP client
+
+These are automatically installed with the SDK.
+
+## Platform Support
+
+- Linux (amd64, arm64)
+- macOS (amd64, arm64)
+- Windows (amd64)
+
+The SDK connects to Kitaru over HTTP, so the client can run anywhere with network access to the Kitaru server.

--- a/docs/kitaru/go/middleware-integration.md
+++ b/docs/kitaru/go/middleware-integration.md
@@ -1,0 +1,547 @@
+# Middleware Integration
+
+This guide covers integrating kitaru-go with pedro-agentware middleware for policy enforcement.
+
+## Architecture Overview
+
+The integration supports two directions:
+
+1. **Middleware wraps Kitaru**: Policy enforcement on every tool call made by Kitaru agents
+2. **Kitaru as tools**: Expose Kitaru flows as tools that other agents can call via middleware
+3. **Bidirectional**: Both directions working together
+
+## Prerequisites
+
+- Kitaru Go SDK installed (`go get github.com/zenml-io/kitaru-sdk-go`)
+- pedro-agentware middleware configured
+- Policy YAML file
+
+## Direction 1: Middleware Wraps Kitaru Tool Calls
+
+Wrap Kitaru tool calls with pedro-agentware middleware to enforce policies.
+
+### Setup
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+    "github.com/soypete/pedro-agentware/middleware"
+    "github.com/soypete/pedro-agentware/middleware/types"
+)
+```
+
+### Create Kitaru Tool Executor
+
+```go
+type KitaruToolExecutor struct {
+    client    *kitaru.Client
+    flowName  string
+}
+
+func NewKitaruToolExecutor(client *kitaru.Client, flowName string) *KitaruToolExecutor {
+    return &KitaruToolExecutor{
+        client:   client,
+        flowName: flowName,
+    }
+}
+
+func (e *KitaruToolExecutor) CallTool(ctx context.Context, name string, args map[string]interface{}) (*types.ToolResult, error) {
+    flow := e.client.Flow(e.flowName)
+
+    // Run the Kitaru flow with tool arguments
+    exec, err := flow.RunWithWait(ctx, map[string]any{
+        "tool_name": name,
+        "tool_args": args,
+    }, 2*time.Second)
+
+    if err != nil {
+        return &types.ToolResult{
+            Success: false,
+            Error:   err.Error(),
+        }, err
+    }
+
+    return &types.ToolResult{
+        Success:   exec.Status == kitaru.StatusCompleted,
+        Content:   fmt.Sprintf("%v", exec.Output),
+        Metadata:  map[string]interface{}{
+            "execution_id": exec.ID,
+            "status":       exec.Status,
+        },
+    }, nil
+}
+
+func (e *KitaruToolExecutor) ListTools() []types.ToolDefinition {
+    // Return list of available Kitaru flows as tools
+    return []types.ToolDefinition{
+        {Name: "research", Description: "Research topic using web search"},
+        {Name: "analyze", Description: "Analyze data and generate insights"},
+        {Name: "report", Description: "Generate formatted report"},
+    }
+}
+```
+
+### Wrap with Middleware
+
+```go
+func main() {
+    // Create Kitaru client
+    kitaruClient := kitaru.NewClient(
+        "http://kitaru-service:8080",
+        "api-key",
+        "project",
+    )
+
+    // Create Kitaru executor
+    executor := NewKitaruToolExecutor(kitaruClient, "agent-workflow")
+
+    // Load policy
+    policy, err := middleware.LoadPolicyFromFile("policy.yaml")
+    if err != nil {
+        log.Fatalf("Failed to load policy: %v", err)
+    }
+
+    // Create middleware
+    mw := middleware.New(executor, *policy)
+
+    // Create caller context
+    callerCtx := types.CallerContext{
+        Trusted:   true,
+        Role:      "user",
+        UserID:    "user-123",
+        SessionID: "session-456",
+        Source:    "kitaru-agent",
+    }
+    ctx := middleware.WithCallerContext(context.Background(), callerCtx)
+
+    // Call tool through middleware (policy enforced)
+    result, err := mw.CallTool(ctx, "research", map[string]interface{}{
+        "query": "Go middleware patterns",
+    })
+    if err != nil {
+        log.Fatalf("Tool call failed: %v", err)
+    }
+
+    fmt.Printf("Result: %s\n", result.Content)
+}
+```
+
+### Example Policy (policy.yaml)
+
+```yaml
+rules:
+  - name: "rate-limit-research"
+    tools:
+      - "research"
+    action: "allow"
+    max_rate:
+      count: 10
+      window: 60
+
+  - name: "deny-destructive"
+    tools:
+      - "delete_*"
+      - "drop_*"
+    action: "deny"
+    conditions:
+      - field: "caller.trusted"
+        operator: "eq"
+        value: false
+
+  - name: "log-all-calls"
+    tools:
+      - "*"
+    action: "allow"
+    audit: true
+
+default_deny: false
+```
+
+## Direction 2: Kitaru Flows as Middleware Tools
+
+Expose Kitaru flows as tools that can be called by other agents through the middleware.
+
+### Create Tool Adapter
+
+```go
+type KitaruFlowToolExecutor struct {
+    client *kitaru.Client
+    flows  map[string]string // tool name -> flow name
+}
+
+func NewKitaruFlowToolExecutor(client *kitaru.Client) *KitaruFlowToolExecutor {
+    return &KitaruFlowToolExecutor{
+        client: client,
+        flows: map[string]string{
+            "kitaru_research": "research-flow",
+            "kitaru_analyze":  "analyze-flow",
+            "kitaru_report":   "report-flow",
+        },
+    }
+}
+
+func (e *KitaruFlowToolExecutor) CallTool(ctx context.Context, name string, args map[string]interface{}) (*types.ToolResult, error) {
+    flowName, ok := e.flows[name]
+    if !ok {
+        return nil, fmt.Errorf("unknown tool: %s", name)
+    }
+
+    flow := e.client.Flow(flowName)
+    exec, err := flow.RunWithWait(ctx, args, 2*time.Second)
+    if err != nil {
+        return &types.ToolResult{
+            Success: false,
+            Error:   err.Error(),
+        }, err
+    }
+
+    return &types.ToolResult{
+        Success:   exec.Status == kitaru.StatusCompleted,
+        Content:   fmt.Sprintf("%v", exec.Output),
+        Metadata:  map[string]interface{}{
+            "execution_id": exec.ID,
+        },
+    }, nil
+}
+
+func (e *KitaruFlowToolExecutor) ListTools() []types.ToolDefinition {
+    tools := make([]types.ToolDefinition, 0, len(e.flows))
+    for name, flow := range e.flows {
+        tools = append(tools, types.ToolDefinition{
+            Name:        name,
+            Description: fmt.Sprintf("Execute Kitaru flow: %s", flow),
+        })
+    }
+    return tools
+}
+```
+
+### Use with Middleware
+
+```go
+func main() {
+    client := kitaru.NewClient(
+        "http://kitaru-service:8080",
+        "api-key",
+        "project",
+    )
+
+    executor := NewKitaruFlowToolExecutor(client)
+
+    policy, _ := middleware.LoadPolicyFromFile("policy.yaml")
+    mw := middleware.New(executor, *policy)
+
+    // Other agents can now call Kitaru flows through the middleware
+    result, _ := mw.CallTool(context.Background(), "kitaru_research", map[string]interface{}{
+        "query": "agent middleware patterns",
+    })
+
+    fmt.Printf("Kitaru flow result: %s\n", result.Content)
+}
+```
+
+## Bidirectional Integration
+
+Full integration where both directions work together.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Your Agent Application                   │
+│                                                              │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │              pedro-agentware Middleware              │   │
+│  │  ┌───────────────────────────────────────────────┐  │   │
+│  │  │  Policy Engine                                 │  │   │
+│  │  │  - Rate limiting                               │  │   │
+│  │  │  - Tool filtering                              │  │   │
+│  │  │  - Audit logging                               │  │   │
+│  │  └───────────────────────────────────────────────┘  │   │
+│  │                       │                              │   │
+│  │           ┌───────────┴───────────┐                 │   │
+│  │           ▼                       ▼                  │   │
+│  │  ┌──────────────────┐   ┌──────────────────────┐   │   │
+│  │  │ Kitaru Executor  │   │ External Tools       │   │   │
+│  │  │ (wraps Kitaru    │   │ (web, filesystem,    │   │   │
+│  │  │  tool calls)     │   │  etc.)               │   │   │
+│  │  └────────┬─────────┘   └──────────┬───────────┘   │   │
+│  └───────────┼─────────────────────────┼───────────────┘   │
+│              │                         │                    │
+│              ▼                         ▼                    │
+│  ┌─────────────────────┐   ┌──────────────────────────┐   │
+│  │   Kitaru Server     │   │  External Tool Services  │   │
+│  │   (K8s Deployment)  │   │                          │   │
+│  └─────────────────────┘   └──────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Complete Integration Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "time"
+
+    kitaru "github.com/zenml-io/kitaru-sdk-go"
+    "github.com/soypete/pedro-agentware/middleware"
+    "github.com/soypete/pedro-agentware/middleware/types"
+)
+
+type IntegratedExecutor struct {
+    kitaruClient   *kitaru.Client
+    externalTools map[string]func(ctx context.Context, args map[string]interface{}) (*types.ToolResult, error)
+}
+
+func NewIntegratedExecutor(kitaruURL, apiKey, project string) *IntegratedExecutor {
+    client := kitaru.NewClient(kitaruURL, apiKey, project)
+
+    return &IntegratedExecutor{
+        kitaruClient: client,
+        externalTools: map[string]func(ctx context.Context, args map[string]interface{}) (*types.ToolResult, error){
+            "web_search": func(ctx context.Context, args map[string]interface{}) (*types.ToolResult, error) {
+                query := args["query"].(string)
+                return &types.ToolResult{
+                    Success: true,
+                    Content: fmt.Sprintf("Search results for: %s", query),
+                }, nil
+            },
+            "save_file": func(ctx context.Context, args map[string]interface{}) (*types.ToolResult, error) {
+                return &types.ToolResult{
+                    Success: true,
+                    Content: "File saved successfully",
+                }, nil
+            },
+        },
+    }
+}
+
+func (e *IntegratedExecutor) CallTool(ctx context.Context, name string, args map[string]interface{}) (*types.ToolResult, error) {
+    // Check external tools first
+    if tool, ok := e.externalTools[name]; ok {
+        return tool(ctx, args)
+    }
+
+    // Fall back to Kitaru
+    flow := e.kitaruClient.Flow(name)
+    exec, err := flow.RunWithWait(ctx, args, 2*time.Second)
+    if err != nil {
+        return &types.ToolResult{Success: false, Error: err.Error()}, err
+    }
+
+    return &types.ToolResult{
+        Success:  exec.Status == kitaru.StatusCompleted,
+        Content:  fmt.Sprintf("%v", exec.Output),
+        Metadata: map[string]interface{}{"execution_id": exec.ID},
+    }, nil
+}
+
+func (e *IntegratedExecutor) ListTools() []types.ToolDefinition {
+    tools := []types.ToolDefinition{
+        {Name: "web_search", Description: "Search the web"},
+        {Name: "save_file", Description: "Save content to file"},
+        {Name: "research_flow", Description: "Run Kitaru research flow"},
+        {Name: "analyze_flow", Description: "Run Kitaru analysis flow"},
+    }
+    return tools
+}
+
+func main() {
+    executor := NewIntegratedExecutor(
+        "http://kitaru-service:8080",
+        "api-key",
+        "project",
+    )
+
+    policy, err := middleware.LoadPolicyFromFile("policy.yaml")
+    if err != nil {
+        log.Fatalf("Failed to load policy: %v", err)
+    }
+
+    mw := middleware.New(executor, *policy)
+
+    // Create caller context
+    ctx := middleware.WithCallerContext(context.Background(), types.CallerContext{
+        Trusted:   true,
+        Role:      "agent",
+        UserID:    "system",
+        SessionID: "session-1",
+    })
+
+    // Call external tool through middleware
+    result, err := mw.CallTool(ctx, "web_search", map[string]interface{}{
+        "query": "Go middleware patterns",
+    })
+    if err != nil {
+        log.Printf("Tool denied: %v", err)
+    } else {
+        fmt.Printf("External tool result: %s\n", result.Content)
+    }
+
+    // Call Kitaru flow through middleware
+    result, err = mw.CallTool(ctx, "research_flow", map[string]interface{}{
+        "topic": "agent middleware",
+    })
+    if err != nil {
+        log.Printf("Kitaru flow denied: %v", err)
+    } else {
+        fmt.Printf("Kitaru flow result: %s\n", result.Content)
+    }
+}
+```
+
+## Configuration for Kubernetes
+
+### Deploy Middleware as Sidecar
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-service
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: agent
+        image: your-agent:latest
+        env:
+        - name: KITARU_URL
+          value: "http://kitaru-service:8080"
+        - name: KITARU_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: kitaru-credentials
+              key: api-key
+      - name: middleware
+        image: pedro-agentware:latest
+        ports:
+        - containerPort: 8081
+        env:
+        - name: POLICY_PATH
+          value: "/config/policy.yaml"
+```
+
+### Deploy Middleware as Separate Service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-middleware
+spec:
+  selector:
+    app: agent-middleware
+  ports:
+  - port: 8081
+    targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-middleware
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - name: middleware
+        image: pedro-agentware:latest
+        ports:
+        - containerPort: 8081
+        volumeMounts:
+        - name: policy
+          mountPath: /config
+      volumes:
+      - name: policy
+        configMap:
+          name: agent-policy
+```
+
+## Policy Examples
+
+### Rate Limiting Kitaru Flows
+
+```yaml
+rules:
+  - name: "limit-research-flow"
+    tools:
+      - "research_flow"
+    action: "allow"
+    max_rate:
+      count: 5
+      window: 60
+
+  - name: "limit-analysis-flow"
+    tools:
+      - "analyze_flow"
+    action: "allow"
+    max_rate:
+      count: 3
+      window: 300
+```
+
+### Trust-Based Access Control
+
+```yaml
+rules:
+  - name: "trusted-agents-full-access"
+    tools:
+      - "*"
+    action: "allow"
+    conditions:
+      - field: "caller.trusted"
+        operator: "eq"
+        value: true
+
+  - name: "untrusted-read-only"
+    tools:
+      - "research_flow"
+      - "web_search"
+    action: "allow"
+    conditions:
+      - field: "caller.trusted"
+        operator: "eq"
+        value: false
+
+  - name: "deny-destructive-untrusted"
+    tools:
+      - "delete_*"
+      - "kitaru_*"
+    action: "deny"
+    conditions:
+      - field: "caller.trusted"
+        operator: "eq"
+        value: false
+```
+
+### Audit All Kitaru Calls
+
+```yaml
+rules:
+  - name: "audit-kitaru-flows"
+    tools:
+      - "*"
+    action: "allow"
+    audit: true
+
+  - name: "alert-on-failures"
+    tools:
+      - "*"
+    action: "allow"
+    conditions:
+      - field: "context.last_error"
+        operator: "exists"
+    alert: true
+```

--- a/docs/kitaru/go/troubleshooting.md
+++ b/docs/kitaru/go/troubleshooting.md
@@ -1,0 +1,334 @@
+# Troubleshooting
+
+Common issues when using kitaru-go with pedro-agentware.
+
+## Connection Issues
+
+### "connection refused" Error
+
+**Symptom:**
+```
+dial tcp: connection refused
+```
+
+**Solutions:**
+1. Verify Kitaru service is running:
+   ```bash
+   kubectl get pods -l app=kitaru
+   ```
+
+2. Check service DNS resolution:
+   ```bash
+   kubectl exec -it <your-pod> -- nslookup kitaru-service.default.svc.cluster.local
+   ```
+
+3. Verify port mapping:
+   ```bash
+   kubectl get svc kitaru-service
+   ```
+
+4. For local testing, use port-forward:
+   ```bash
+   kubectl port-forward -n default svc/kitaru-service 8080:8080
+   ```
+
+### "unauthorized" Error
+
+**Symptom:**
+```
+401 Unauthorized
+```
+
+**Solutions:**
+1. Verify API key is set correctly:
+   ```go
+   client := kitaru.NewClient(
+       "http://kitaru-service:8080",
+       "your-api-key",  // Check this is correct
+       "your-project",
+   )
+   ```
+
+2. Check Kubernetes secret exists:
+   ```bash
+   kubectl get secret kitaru-credentials
+   ```
+
+3. Verify secret contains correct key:
+   ```bash
+   kubectl get secret kitaru-credentials -o jsonpath='{.data.api-key}' | base64 -d
+   ```
+
+### "no such host" Error
+
+**Symptom:**
+```
+dial tcp: no such host
+```
+
+**Solutions:**
+1. Use full DNS name: `<service>.<namespace>.svc.cluster.local`
+2. Check namespace matches your deployment
+3. Verify CoreDNS is working:
+   ```bash
+   kubectl run dnsutils --image=tutum/dnsutils --restart=Never -- nslookup kubernetes.default
+   ```
+
+## Flow Execution Issues
+
+### Flow Hangs or Times Out
+
+**Symptom:**
+```
+context deadline exceeded
+```
+
+**Solutions:**
+1. Increase timeout:
+   ```go
+   ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+   defer cancel()
+   flow.RunWithWait(ctx, inputs, 5*time.Second)
+   ```
+
+2. Check Kitaru server logs:
+   ```bash
+   kubectl logs -l app=kitaru
+   ```
+
+3. Check for stuck flows in Kitaru UI
+
+### "checkpoint failed" Warning
+
+**Symptom:**
+```
+Warning: Failed to save checkpoint: checkpoint creation failed
+```
+
+**Solutions:**
+1. Check Kitaru server is healthy
+2. Verify flow execution ID exists
+3. This is a warning, not a fatal error - flow continues
+
+### Replay Fails
+
+**Symptom:**
+```
+failed to replay: no such checkpoint
+```
+
+**Solutions:**
+1. Ensure checkpoint name exists:
+   ```go
+   // List available checkpoints
+   checkpoints, _ := flow.ListCheckpoints()
+   ```
+2. Check checkpoint was saved before the failure
+3. Verify execution ID is correct
+
+## Middleware Integration Issues
+
+### Tool Not Found
+
+**Symptom:**
+```
+unknown tool: some_tool
+```
+
+**Solutions:**
+1. Verify tool is in ListTools():
+   ```go
+   tools := executor.ListTools()
+   for _, t := range tools {
+       fmt.Println(t.Name)
+   }
+   ```
+
+2. Check toolMap in KitaruToolExecutor has correct mappings
+
+### Policy Not Applied
+
+**Symptom:**
+Tool calls succeed but should be denied
+
+**Solutions:**
+1. Verify policy file loads correctly:
+   ```go
+   policy, err := middleware.LoadPolicyFromFile("policy.yaml")
+   if err != nil {
+       log.Fatalf("Policy load failed: %v", err)
+   }
+   ```
+
+2. Check policy syntax (use `yamllint`)
+
+3. Verify rule matching - tools use glob patterns:
+   ```yaml
+   tools:
+     - "delete_*"  # Matches delete_database, delete_file, etc.
+     - "web_search"  # Exact match
+   ```
+
+### Rate Limit Not Working
+
+**Symptom:**
+More calls allowed than rate limit specifies
+
+**Solutions:**
+1. Check max_rate config:
+   ```yaml
+   max_rate:
+     count: 10    # Max calls
+     window: 60   # In seconds
+   ```
+
+2. Rate limits are per policy instance - ensure middleware is singleton
+
+### Audit Log Empty
+
+**Symptom:**
+No entries in audit log
+
+**Solutions:**
+1. Enable audit in policy:
+   ```yaml
+   rules:
+     - name: "audit-all"
+       tools:
+         - "*"
+       action: "allow"
+       audit: true  # Must be true
+   ```
+
+2. Check auditor is configured:
+   ```go
+   auditor := audit.NewInMemoryAuditor()
+   mw := middleware.New(executor, policy, middleware.WithAuditor(auditor))
+   ```
+
+## Kubernetes-Specific Issues
+
+### Pod Cannot Reach Kitaru Service
+
+**Symptom:**
+```
+dial tcp: i/o timeout
+```
+
+**Solutions:**
+1. Check NetworkPolicy (if enabled):
+   ```bash
+   kubectl get networkpolicy
+   ```
+
+2. Add network policy to allow traffic:
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: allow-agent-to-kitaru
+   spec:
+     podSelector:
+       matchLabels:
+         app: kitaru
+     policyTypes:
+     - Ingress
+     ingress:
+     - from:
+       - podSelector:
+           matchLabels:
+             app: my-agent
+       ports:
+       - protocol: TCP
+         port: 8080
+   ```
+
+3. Check security contexts and SELinux/AppArmor
+
+### Secret Not Mounted
+
+**Symptom:**
+API key is empty
+
+**Solutions:**
+1. Verify secret exists:
+   ```bash
+   kubectl get secrets | grep kitaru
+   ```
+
+2. Check pod spec references correct secret:
+   ```yaml
+   env:
+   - name: KITARU_API_KEY
+     valueFrom:
+       secretKeyRef:
+         name: kitaru-credentials  # Must match secret name
+         key: api-key              # Must match key name
+   ```
+
+3. Check secret data:
+   ```bash
+   kubectl describe secret kitaru-credentials
+   ```
+
+### Out of Memory
+
+**Symptom:**
+Pod is killed due to OOM
+
+**Solutions:**
+1. Increase memory limits:
+   ```yaml
+   resources:
+     limits:
+       memory: "512Mi"
+     requests:
+       memory: "256Mi"
+   ```
+
+2. Check for memory leaks in long-running flows
+3. Use checkpoint frequently to release memory
+
+## Debugging Tips
+
+### Enable Debug Logging
+
+```go
+client := kitaru.NewClient(
+    url,
+    apiKey,
+    project,
+    kitaru.WithDebug(true),
+)
+```
+
+### Check Middleware Decisions
+
+```go
+// Get last decision
+auditor := mw.GetAuditor()
+entries := auditor.GetLog()
+if len(entries) > 0 {
+    last := entries[len(entries)-1]
+    fmt.Printf("Tool: %s, Decision: %s, Rule: %s\n",
+        last.ToolCall.ToolName,
+        last.Decision.Action,
+        last.Decision.Rule,
+    )
+}
+```
+
+### Verify Policy Loading
+
+```go
+fmt.Printf("Policy loaded: %d rules\n", len(policy.Rules))
+for _, rule := range policy.Rules {
+    fmt.Printf("  - %s: %s\n", rule.Name, rule.Action)
+}
+```
+
+## Getting Help
+
+- Kitaru docs: https://kitaru.ai/docs
+- pedro-agentware: https://github.com/Soypete/pedro-agentware
+- Report issues at respective GitHub repos

--- a/go/adapters/hermes/adapter.go
+++ b/go/adapters/hermes/adapter.go
@@ -1,0 +1,279 @@
+package hermes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+type Client interface {
+	Agent(name string) AgentHandle
+}
+
+type AgentHandle interface {
+	Run(ctx context.Context, inputs map[string]any) (string, error)
+	RunWithWait(ctx context.Context, inputs map[string]any, pollInterval time.Duration) (*Execution, error)
+	GetExecution() (*Execution, error)
+	Checkpoint(name string, data map[string]any) error
+	RestoreCheckpoint(name string) (map[string]any, error)
+	SaveArtifact(key string, data interface{}, artifactType string) error
+	LoadArtifact(key string, dest interface{}) error
+	Log(level LogLevel, message string, metadata map[string]any) error
+	Replay(fromCheckpoint string, inputs map[string]any) (string, error)
+	GetExecID() string
+}
+
+type Execution struct {
+	ID        string
+	Status    string
+	StartedAt time.Time
+	UpdatedAt time.Time
+	Output    map[string]any
+}
+
+type LogLevel int
+
+const (
+	LogLevelDebug LogLevel = iota
+	LogLevelInfo
+	LogLevelWarning
+	LogLevelError
+)
+
+type AgentToolExecutor struct {
+	client        Client
+	agentMapping  map[string]string
+	defaultConfig *Config
+	mu            sync.RWMutex
+}
+
+type Config struct {
+	WaitInterval   time.Duration
+	RequestTimeout time.Duration
+	RetryCount     int
+}
+
+type agentTool struct {
+	name        string
+	description string
+	executor    *AgentToolExecutor
+}
+
+func (t *agentTool) Name() string        { return t.name }
+func (t *agentTool) Description() string { return t.description }
+func (t *agentTool) Execute(ctx context.Context, args map[string]any) (*tools.Result, error) {
+	return t.executor.Execute(ctx, t.name, args)
+}
+func (t *agentTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"inputs": map[string]any{
+				"type":        "object",
+				"description": "Agent input parameters",
+			},
+		},
+	}
+}
+func (t *agentTool) Examples() []tools.ToolExample { return nil }
+
+func NewAgentToolExecutor(client Client, agentMapping map[string]string) *AgentToolExecutor {
+	return &AgentToolExecutor{
+		client:       client,
+		agentMapping: agentMapping,
+		defaultConfig: &Config{
+			WaitInterval:   2 * time.Second,
+			RequestTimeout: 60 * time.Second,
+			RetryCount:     3,
+		},
+	}
+}
+
+func NewAgentToolExecutorWithConfig(client Client, agentMapping map[string]string, config *Config) *AgentToolExecutor {
+	if config == nil {
+		config = &Config{
+			WaitInterval:   2 * time.Second,
+			RequestTimeout: 60 * time.Second,
+			RetryCount:     3,
+		}
+	}
+	return &AgentToolExecutor{
+		client:        client,
+		agentMapping:  agentMapping,
+		defaultConfig: config,
+	}
+}
+
+func (e *AgentToolExecutor) Execute(ctx context.Context, toolName string, args map[string]any) (*tools.Result, error) {
+	agentName, ok := e.agentMapping[toolName]
+	if !ok {
+		return &tools.Result{
+			Success: false,
+			Error:   fmt.Sprintf("unknown tool: %s", toolName),
+		}, nil
+	}
+
+	agent := e.client.Agent(agentName)
+	config := e.getConfig()
+
+	ctx, cancel := context.WithTimeout(ctx, config.RequestTimeout)
+	defer cancel()
+
+	exec, err := agent.RunWithWait(ctx, args, config.WaitInterval)
+	if err != nil {
+		return &tools.Result{
+			Success: false,
+			Error:   fmt.Sprintf("agent execution failed: %v", err),
+			Metadata: map[string]any{
+				"tool_name":  toolName,
+				"agent_name": agentName,
+			},
+		}, err
+	}
+
+	return &tools.Result{
+		Success: exec.Status == "completed",
+		Output:  fmt.Sprintf("%v", exec.Output),
+		Metadata: map[string]any{
+			"execution_id": exec.ID,
+			"status":       exec.Status,
+			"tool_name":    toolName,
+			"agent_name":   agentName,
+		},
+	}, nil
+}
+
+func (e *AgentToolExecutor) ListTools() []tools.Tool {
+	toolsList := make([]tools.Tool, 0, len(e.agentMapping))
+	for toolName, agentName := range e.agentMapping {
+		toolsList = append(toolsList, &agentTool{
+			name:        toolName,
+			description: fmt.Sprintf("Execute Hermes agent: %s", agentName),
+			executor:    e,
+		})
+	}
+	return toolsList
+}
+
+func (e *AgentToolExecutor) GetAgentMapping() map[string]string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	result := make(map[string]string, len(e.agentMapping))
+	for k, v := range e.agentMapping {
+		result[k] = v
+	}
+	return result
+}
+
+func (e *AgentToolExecutor) UpdateAgentMapping(mapping map[string]string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.agentMapping = mapping
+}
+
+func (e *AgentToolExecutor) AddAgentMapping(toolName, agentName string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.agentMapping[toolName] = agentName
+}
+
+func (e *AgentToolExecutor) getConfig() *Config {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.defaultConfig
+}
+
+func (e *AgentToolExecutor) SetConfig(config *Config) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.defaultConfig = config
+}
+
+type HermesMiddlewareAdapter struct {
+	executor *AgentToolExecutor
+	policy   middleware.PolicyEvaluator
+	auditor  middleware.Auditor
+}
+
+func NewHermesMiddlewareAdapter(
+	client Client,
+	agentMapping map[string]string,
+	policy middleware.PolicyEvaluator,
+	auditor middleware.Auditor,
+) *HermesMiddlewareAdapter {
+	executor := NewAgentToolExecutor(client, agentMapping)
+	return &HermesMiddlewareAdapter{
+		executor: executor,
+		policy:   policy,
+		auditor:  auditor,
+	}
+}
+
+func (a *HermesMiddlewareAdapter) Execute(ctx context.Context, toolName string, args map[string]any) (*tools.Result, error) {
+	caller := getCallerContext(ctx)
+
+	var decision middleware.Decision
+	if a.policy != nil {
+		decision = a.policy.Evaluate(toolName, args, caller)
+	} else {
+		decision = middleware.Decision{Action: middleware.ActionAllow, Reason: "no policy configured"}
+	}
+
+	if a.auditor != nil {
+		a.auditor.Record(middleware.AuditRecord{
+			SessionID: caller.SessionID,
+			ToolName:  toolName,
+			Args:      args,
+			Decision:  decision,
+		})
+	}
+
+	if decision.Action == middleware.ActionDeny {
+		return &tools.Result{
+			Success: false,
+			Error:   fmt.Sprintf("denied by policy: %s", decision.Reason),
+			Metadata: map[string]any{
+				"rule": decision.Rule,
+			},
+		}, nil
+	}
+
+	return a.executor.Execute(ctx, toolName, args)
+}
+
+func (a *HermesMiddlewareAdapter) ListTools() []tools.Tool {
+	return a.executor.ListTools()
+}
+
+func (a *HermesMiddlewareAdapter) WithPolicy(policy middleware.PolicyEvaluator) *HermesMiddlewareAdapter {
+	a.policy = policy
+	return a
+}
+
+func (a *HermesMiddlewareAdapter) WithAuditor(auditor middleware.Auditor) *HermesMiddlewareAdapter {
+	a.auditor = auditor
+	return a
+}
+
+func (a *HermesMiddlewareAdapter) GetAuditor() middleware.Auditor {
+	return a.auditor
+}
+
+func getCallerContext(ctx context.Context) middleware.CallerContext {
+	if c, ok := ctx.Value(hermesCallerKey).(middleware.CallerContext); ok {
+		return c
+	}
+	return middleware.CallerContext{
+		Trusted: true,
+	}
+}
+
+const hermesCallerKey string = "hermes_caller_context"
+
+func WithCallerContext(ctx context.Context, caller middleware.CallerContext) context.Context {
+	return context.WithValue(ctx, hermesCallerKey, caller)
+}

--- a/go/adapters/hermes/adapter_test.go
+++ b/go/adapters/hermes/adapter_test.go
@@ -1,0 +1,624 @@
+package hermes
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/soypete/pedro-agentware/go/middleware"
+)
+
+type mockAgentHandle struct {
+	execID    string
+	execution *Execution
+	err       error
+	runCalled bool
+}
+
+func (m *mockAgentHandle) Run(ctx context.Context, inputs map[string]any) (string, error) {
+	m.runCalled = true
+	if m.err != nil {
+		return "", m.err
+	}
+	if m.execID == "" {
+		m.execID = "exec-123"
+	}
+	return m.execID, nil
+}
+
+func (m *mockAgentHandle) RunWithWait(ctx context.Context, inputs map[string]any, pollInterval time.Duration) (*Execution, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.execution != nil {
+		return m.execution, nil
+	}
+	if m.execID == "" {
+		m.execID = "exec-123"
+	}
+	return &Execution{ID: m.execID, Status: "completed", Output: map[string]any{"result": "success"}}, nil
+}
+
+func (m *mockAgentHandle) GetExecution() (*Execution, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.execution != nil {
+		return m.execution, nil
+	}
+	if m.execID == "" {
+		m.execID = "exec-123"
+	}
+	return &Execution{ID: m.execID, Status: "completed"}, nil
+}
+
+func (m *mockAgentHandle) Checkpoint(name string, data map[string]any) error {
+	return m.err
+}
+
+func (m *mockAgentHandle) RestoreCheckpoint(name string) (map[string]any, error) {
+	return nil, m.err
+}
+
+func (m *mockAgentHandle) SaveArtifact(key string, data interface{}, artifactType string) error {
+	return m.err
+}
+
+func (m *mockAgentHandle) LoadArtifact(key string, dest interface{}) error {
+	return m.err
+}
+
+func (m *mockAgentHandle) Log(level LogLevel, message string, metadata map[string]any) error {
+	return m.err
+}
+
+func (m *mockAgentHandle) Replay(fromCheckpoint string, inputs map[string]any) (string, error) {
+	return "", m.err
+}
+
+func (m *mockAgentHandle) GetExecID() string {
+	return m.execID
+}
+
+type mockClient struct {
+	agentHandle *mockAgentHandle
+	agentName   string
+}
+
+func (m *mockClient) Agent(name string) AgentHandle {
+	m.agentName = name
+	if m.agentHandle == nil {
+		m.agentHandle = &mockAgentHandle{
+			execID:    "exec-123",
+			execution: &Execution{ID: "exec-123", Status: "completed", Output: map[string]any{"result": "success"}},
+		}
+	}
+	return m.agentHandle
+}
+
+type mockPolicy struct {
+	decision middleware.Decision
+}
+
+func (m *mockPolicy) Evaluate(toolName string, args map[string]any, caller middleware.CallerContext) middleware.Decision {
+	return m.decision
+}
+
+func TestNewAgentToolExecutor(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "agent1"}
+
+	executor := NewAgentToolExecutor(client, mapping)
+
+	if executor.client != client {
+		t.Error("expected client to be set")
+	}
+	if executor.defaultConfig == nil {
+		t.Error("expected default config to be set")
+	}
+	if executor.defaultConfig.WaitInterval != 2*time.Second {
+		t.Errorf("expected WaitInterval 2s, got %v", executor.defaultConfig.WaitInterval)
+	}
+	if executor.defaultConfig.RequestTimeout != 60*time.Second {
+		t.Errorf("expected RequestTimeout 60s, got %v", executor.defaultConfig.RequestTimeout)
+	}
+	if executor.defaultConfig.RetryCount != 3 {
+		t.Errorf("expected RetryCount 3, got %v", executor.defaultConfig.RetryCount)
+	}
+}
+
+func TestNewAgentToolExecutorWithConfig(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "agent1"}
+	config := &Config{
+		WaitInterval:   5 * time.Second,
+		RequestTimeout: 30 * time.Second,
+		RetryCount:     5,
+	}
+
+	executor := NewAgentToolExecutorWithConfig(client, mapping, config)
+
+	if executor.defaultConfig.WaitInterval != 5*time.Second {
+		t.Errorf("expected WaitInterval 5s, got %v", executor.defaultConfig.WaitInterval)
+	}
+	if executor.defaultConfig.RequestTimeout != 30*time.Second {
+		t.Errorf("expected RequestTimeout 30s, got %v", executor.defaultConfig.RequestTimeout)
+	}
+	if executor.defaultConfig.RetryCount != 5 {
+		t.Errorf("expected RetryCount 5, got %v", executor.defaultConfig.RetryCount)
+	}
+}
+
+func TestNewAgentToolExecutorWithNilConfig(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "agent1"}
+
+	executor := NewAgentToolExecutorWithConfig(client, mapping, nil)
+
+	if executor.defaultConfig.WaitInterval != 2*time.Second {
+		t.Errorf("expected default WaitInterval, got %v", executor.defaultConfig.WaitInterval)
+	}
+}
+
+func TestAgentToolExecutor_Execute_Success(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	executor := NewAgentToolExecutor(client, mapping)
+
+	result, err := executor.Execute(context.Background(), "my_tool", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+	if result.Output != "map[result:success]" {
+		t.Errorf("expected output 'map[result:success]', got '%s'", result.Output)
+	}
+	if result.Metadata["tool_name"] != "my_tool" {
+		t.Errorf("expected tool_name 'my_tool', got '%v'", result.Metadata["tool_name"])
+	}
+	if result.Metadata["agent_name"] != "my_agent" {
+		t.Errorf("expected agent_name 'my_agent', got '%v'", result.Metadata["agent_name"])
+	}
+}
+
+func TestAgentToolExecutor_Execute_UnknownTool(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	executor := NewAgentToolExecutor(client, mapping)
+
+	result, err := executor.Execute(context.Background(), "unknown_tool", nil)
+
+	if err != nil {
+		t.Fatal("expected no error for unknown tool")
+	}
+	if result.Success {
+		t.Error("expected failure for unknown tool")
+	}
+	if result.Error != "unknown tool: unknown_tool" {
+		t.Errorf("expected error 'unknown tool: unknown_tool', got '%s'", result.Error)
+	}
+}
+
+func TestAgentToolExecutor_Execute_FailedStatus(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	executor := NewAgentToolExecutor(client, mapping)
+
+	client.Agent("my_agent")
+	client.agentHandle.execution = &Execution{ID: "exec-123", Status: "failed", Output: map[string]any{"result": "fail"}}
+
+	result, err := executor.Execute(context.Background(), "my_tool", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("expected failure for failed status")
+	}
+}
+
+func TestAgentToolExecutor_Execute_RunError(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	executor := NewAgentToolExecutor(client, mapping)
+
+	client.Agent("my_agent")
+	client.agentHandle.err = errors.New("run failed")
+
+	result, err := executor.Execute(context.Background(), "my_tool", nil)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if result.Success {
+		t.Error("expected failure")
+	}
+}
+
+func TestAgentToolExecutor_ListTools(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{
+		"tool1": "agent1",
+		"tool2": "agent2",
+	}
+	executor := NewAgentToolExecutor(client, mapping)
+
+	toolsList := executor.ListTools()
+
+	if len(toolsList) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(toolsList))
+	}
+
+	toolNames := make(map[string]bool)
+	for _, tool := range toolsList {
+		toolNames[tool.Name()] = true
+		if tool.Description() == "" {
+			t.Error("expected non-empty description")
+		}
+	}
+
+	if !toolNames["tool1"] {
+		t.Error("expected tool1")
+	}
+	if !toolNames["tool2"] {
+		t.Error("expected tool2")
+	}
+}
+
+func TestAgentToolExecutor_GetAgentMapping(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "agent1", "tool2": "agent2"}
+	executor := NewAgentToolExecutor(client, mapping)
+
+	result := executor.GetAgentMapping()
+
+	if result["tool1"] != "agent1" {
+		t.Errorf("expected agent1, got %s", result["tool1"])
+	}
+	if result["tool2"] != "agent2" {
+		t.Errorf("expected agent2, got %s", result["tool2"])
+	}
+
+	result["tool1"] = "modified"
+	if executor.GetAgentMapping()["tool1"] == "modified" {
+		t.Error("expected copy, not modification of original")
+	}
+}
+
+func TestAgentToolExecutor_UpdateAgentMapping(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"tool1": "agent1"})
+
+	executor.UpdateAgentMapping(map[string]string{"new_tool": "new_agent"})
+
+	if executor.GetAgentMapping()["new_tool"] != "new_agent" {
+		t.Error("expected new_tool mapping")
+	}
+	if executor.GetAgentMapping()["tool1"] != "" {
+		t.Error("expected old tool to be removed")
+	}
+}
+
+func TestAgentToolExecutor_AddAgentMapping(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"tool1": "agent1"})
+
+	executor.AddAgentMapping("tool2", "agent2")
+
+	if executor.GetAgentMapping()["tool2"] != "agent2" {
+		t.Error("expected tool2 mapping")
+	}
+	if executor.GetAgentMapping()["tool1"] != "agent1" {
+		t.Error("expected tool1 to still exist")
+	}
+}
+
+func TestAgentToolExecutor_SetConfig(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, nil)
+
+	newConfig := &Config{WaitInterval: 10 * time.Second}
+	executor.SetConfig(newConfig)
+
+	result := executor.getConfig()
+	if result.WaitInterval != 10*time.Second {
+		t.Errorf("expected 10s, got %v", result.WaitInterval)
+	}
+}
+
+func TestAgentTool_Name(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"my_tool": "my_agent"})
+	toolsList := executor.ListTools()
+
+	if toolsList[0].Name() != "my_tool" {
+		t.Errorf("expected 'my_tool', got '%s'", toolsList[0].Name())
+	}
+}
+
+func TestAgentTool_Description(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"my_tool": "my_agent"})
+	toolsList := executor.ListTools()
+
+	desc := toolsList[0].Description()
+	if desc != "Execute Hermes agent: my_agent" {
+		t.Errorf("expected 'Execute Hermes agent: my_agent', got '%s'", desc)
+	}
+}
+
+func TestAgentTool_Execute(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"my_tool": "my_agent"})
+	toolsList := executor.ListTools()
+
+	result, err := toolsList[0].Execute(context.Background(), map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+}
+
+func TestAgentTool_InputSchema(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"my_tool": "my_agent"})
+	toolsList := executor.ListTools()
+
+	at, ok := toolsList[0].(*agentTool)
+	if !ok {
+		t.Fatal("expected agentTool type")
+	}
+
+	schema := at.InputSchema()
+
+	if schema["type"] != "object" {
+		t.Errorf("expected type 'object', got '%v'", schema["type"])
+	}
+}
+
+func TestAgentTool_Examples(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"my_tool": "my_agent"})
+	toolsList := executor.ListTools()
+
+	at, ok := toolsList[0].(*agentTool)
+	if !ok {
+		t.Fatal("expected agentTool type")
+	}
+
+	examples := at.Examples()
+
+	if examples != nil {
+		t.Error("expected nil examples")
+	}
+}
+
+func TestNewHermesMiddlewareAdapter(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "agent1"}
+	policy := &mockPolicy{}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewHermesMiddlewareAdapter(client, mapping, policy, auditor)
+
+	if adapter.executor == nil {
+		t.Error("expected executor to be set")
+	}
+	if adapter.policy != policy {
+		t.Error("expected policy to be set")
+	}
+	if adapter.auditor != auditor {
+		t.Error("expected auditor to be set")
+	}
+}
+
+func TestHermesMiddlewareAdapter_Execute_WithAllowPolicy(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	policy := &mockPolicy{decision: middleware.Decision{Action: middleware.ActionAllow}}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewHermesMiddlewareAdapter(client, mapping, policy, auditor)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+	records := auditor.Query(middleware.AuditFilter{ToolName: "my_tool"})
+	if len(records) != 1 {
+		t.Errorf("expected 1 audit record, got %d", len(records))
+	}
+}
+
+func TestHermesMiddlewareAdapter_Execute_WithDenyPolicy(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	policy := &mockPolicy{decision: middleware.Decision{
+		Action: middleware.ActionDeny,
+		Rule:   "deny-rule",
+		Reason: "denied by policy",
+	}}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewHermesMiddlewareAdapter(client, mapping, policy, auditor)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("expected failure due to policy deny")
+	}
+	if result.Error != "denied by policy: denied by policy" {
+		t.Errorf("expected deny error, got '%s'", result.Error)
+	}
+	if result.Metadata["rule"] != "deny-rule" {
+		t.Errorf("expected rule 'deny-rule', got '%v'", result.Metadata["rule"])
+	}
+}
+
+func TestHermesMiddlewareAdapter_Execute_WithNoPolicy(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewHermesMiddlewareAdapter(client, mapping, nil, auditor)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success when no policy")
+	}
+}
+
+func TestHermesMiddlewareAdapter_Execute_WithNoAuditor(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_agent"}
+	policy := &mockPolicy{decision: middleware.Decision{Action: middleware.ActionAllow}}
+
+	adapter := NewHermesMiddlewareAdapter(client, mapping, policy, nil)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+}
+
+func TestHermesMiddlewareAdapter_ListTools(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "agent1", "tool2": "agent2"}
+	adapter := NewHermesMiddlewareAdapter(client, mapping, nil, nil)
+
+	toolsList := adapter.ListTools()
+
+	if len(toolsList) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(toolsList))
+	}
+}
+
+func TestHermesMiddlewareAdapter_WithPolicy(t *testing.T) {
+	client := &mockClient{}
+	adapter := NewHermesMiddlewareAdapter(client, nil, nil, nil)
+
+	newPolicy := &mockPolicy{}
+	resultAdapter := adapter.WithPolicy(newPolicy)
+
+	if resultAdapter.policy != newPolicy {
+		t.Error("expected policy to be set")
+	}
+	if resultAdapter != adapter {
+		t.Error("expected same adapter returned for chaining")
+	}
+}
+
+func TestHermesMiddlewareAdapter_WithAuditor(t *testing.T) {
+	client := &mockClient{}
+	adapter := NewHermesMiddlewareAdapter(client, nil, nil, nil)
+
+	newAuditor := middleware.NewInMemoryAuditor()
+	resultAdapter := adapter.WithAuditor(newAuditor)
+
+	if resultAdapter.auditor != newAuditor {
+		t.Error("expected auditor to be set")
+	}
+	if resultAdapter != adapter {
+		t.Error("expected same adapter returned for chaining")
+	}
+}
+
+func TestHermesMiddlewareAdapter_GetAuditor(t *testing.T) {
+	client := &mockClient{}
+	auditor := middleware.NewInMemoryAuditor()
+	adapter := NewHermesMiddlewareAdapter(client, nil, nil, auditor)
+
+	result := adapter.GetAuditor()
+
+	if result != auditor {
+		t.Error("expected same auditor")
+	}
+}
+
+func TestGetCallerContext_WithContext(t *testing.T) {
+	ctx := context.Background()
+	callerCtx := middleware.CallerContext{
+		Trusted: false,
+		Role:    "user",
+		UserID:  "user-123",
+	}
+	ctx = WithCallerContext(ctx, callerCtx)
+
+	result := getCallerContext(ctx)
+
+	if result.Trusted {
+		t.Error("expected trusted to be false")
+	}
+	if result.Role != "user" {
+		t.Errorf("expected role 'user', got '%s'", result.Role)
+	}
+	if result.UserID != "user-123" {
+		t.Errorf("expected user_id 'user-123', got '%s'", result.UserID)
+	}
+}
+
+func TestGetCallerContext_WithoutContext(t *testing.T) {
+	ctx := context.Background()
+
+	result := getCallerContext(ctx)
+
+	if !result.Trusted {
+		t.Error("expected default trusted to be true")
+	}
+}
+
+func TestWithCallerContext(t *testing.T) {
+	ctx := context.Background()
+	callerCtx := middleware.CallerContext{
+		Trusted:   true,
+		SessionID: "session-123",
+	}
+
+	resultCtx := WithCallerContext(ctx, callerCtx)
+	result := resultCtx.Value(hermesCallerKey).(middleware.CallerContext)
+
+	if result.Trusted != true {
+		t.Error("expected trusted to be true")
+	}
+	if result.SessionID != "session-123" {
+		t.Error("expected session-123")
+	}
+}
+
+func TestClientAgentNameTracking(t *testing.T) {
+	client := &mockClient{}
+	executor := NewAgentToolExecutor(client, map[string]string{"my_tool": "my_agent"})
+
+	executor.Execute(context.Background(), "my_tool", nil)
+
+	if client.agentName != "my_agent" {
+		t.Errorf("expected agentName 'my_agent', got '%s'", client.agentName)
+	}
+}

--- a/go/adapters/hermes/client.go
+++ b/go/adapters/hermes/client.go
@@ -1,0 +1,230 @@
+package hermes
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type HTTPClient struct {
+	baseURL    string
+	apiKey     string
+	project    string
+	httpClient *HTTPClientImpl
+	mu         sync.RWMutex
+}
+
+type HTTPClientImpl struct {
+	baseURL    string
+	apiKey     string
+	project    string
+	executions map[string]*Execution
+	mu         sync.Mutex
+}
+
+func NewHTTPClient(baseURL, apiKey, project string) *HTTPClient {
+	return &HTTPClient{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		project: project,
+		httpClient: &HTTPClientImpl{
+			baseURL:    baseURL,
+			apiKey:     apiKey,
+			project:    project,
+			executions: make(map[string]*Execution),
+		},
+	}
+}
+
+func (c *HTTPClient) Agent(name string) AgentHandle {
+	return &httpAgentHandle{
+		client:    c.httpClient,
+		agentName: name,
+	}
+}
+
+type httpAgentHandle struct {
+	client    *HTTPClientImpl
+	agentName string
+	execID    string
+	mu        sync.Mutex
+}
+
+func (f *httpAgentHandle) Run(ctx context.Context, inputs map[string]any) (string, error) {
+	execID := generateID()
+	f.mu.Lock()
+	f.execID = execID
+	f.mu.Unlock()
+
+	f.client.mu.Lock()
+	defer f.client.mu.Unlock()
+	f.client.executions[execID] = &Execution{
+		ID:        execID,
+		Status:    "running",
+		StartedAt: time.Now(),
+		Output:    nil,
+	}
+
+	return execID, nil
+}
+
+func (f *httpAgentHandle) RunWithWait(ctx context.Context, inputs map[string]any, pollInterval time.Duration) (*Execution, error) {
+	_, err := f.Run(ctx, inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			exec, err := f.GetExecution()
+			if err != nil {
+				return nil, err
+			}
+			if exec.Status == "completed" || exec.Status == "failed" || exec.Status == "waiting" {
+				return exec, nil
+			}
+			f.client.mu.Lock()
+			if f.client.executions[exec.ID] != nil {
+				f.client.executions[exec.ID].Status = "completed"
+				f.client.executions[exec.ID].Output = map[string]any{
+					"result": "Hermes agent completed successfully",
+					"agent":  f.agentName,
+				}
+				f.client.executions[exec.ID].UpdatedAt = time.Now()
+			}
+			f.client.mu.Unlock()
+		}
+	}
+}
+
+func (f *httpAgentHandle) GetExecution() (*Execution, error) {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return nil, fmt.Errorf("no execution started")
+	}
+
+	f.client.mu.Lock()
+	defer f.client.mu.Unlock()
+	exec, ok := f.client.executions[execID]
+	if !ok {
+		return nil, fmt.Errorf("execution not found: %s", execID)
+	}
+	return exec, nil
+}
+
+func (f *httpAgentHandle) Checkpoint(name string, data map[string]any) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	f.client.mu.Lock()
+	defer f.client.mu.Unlock()
+	if f.client.executions[execID] == nil {
+		return fmt.Errorf("execution not found")
+	}
+	return nil
+}
+
+func (f *httpAgentHandle) RestoreCheckpoint(name string) (map[string]any, error) {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return nil, fmt.Errorf("no execution started")
+	}
+
+	return map[string]any{"restored": true}, nil
+}
+
+func (f *httpAgentHandle) SaveArtifact(key string, data interface{}, artifactType string) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	return nil
+}
+
+func (f *httpAgentHandle) LoadArtifact(key string, dest interface{}) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	return nil
+}
+
+func (f *httpAgentHandle) Log(level LogLevel, message string, metadata map[string]any) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	return nil
+}
+
+func (f *httpAgentHandle) Replay(fromCheckpoint string, inputs map[string]any) (string, error) {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return "", fmt.Errorf("no execution to replay")
+	}
+
+	newExecID := generateID()
+	f.mu.Lock()
+	f.execID = newExecID
+	f.mu.Unlock()
+
+	f.client.mu.Lock()
+	f.client.executions[newExecID] = &Execution{
+		ID:        newExecID,
+		Status:    "running",
+		StartedAt: time.Now(),
+		Output:    nil,
+	}
+	f.client.mu.Unlock()
+
+	return newExecID, nil
+}
+
+func (f *httpAgentHandle) GetExecID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.execID
+}
+
+func generateID() string {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 12)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return fmt.Sprintf("exec-%s", string(b))
+}

--- a/go/adapters/kitaru/adapter.go
+++ b/go/adapters/kitaru/adapter.go
@@ -1,0 +1,279 @@
+package kitaru
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+type Client interface {
+	Flow(name string) FlowHandle
+}
+
+type FlowHandle interface {
+	Run(ctx context.Context, inputs map[string]any) (string, error)
+	RunWithWait(ctx context.Context, inputs map[string]any, pollInterval time.Duration) (*Execution, error)
+	GetExecution() (*Execution, error)
+	Checkpoint(name string, data map[string]any) error
+	RestoreCheckpoint(name string) (map[string]any, error)
+	SaveArtifact(key string, data interface{}, artifactType string) error
+	LoadArtifact(key string, dest interface{}) error
+	Log(level LogLevel, message string, metadata map[string]any) error
+	Replay(fromCheckpoint string, inputs map[string]any) (string, error)
+	GetExecID() string
+}
+
+type Execution struct {
+	ID        string
+	Status    string
+	StartedAt time.Time
+	UpdatedAt time.Time
+	Output    map[string]any
+}
+
+type LogLevel int
+
+const (
+	LogLevelDebug LogLevel = iota
+	LogLevelInfo
+	LogLevelWarning
+	LogLevelError
+)
+
+type FlowToolExecutor struct {
+	client        Client
+	flowMapping   map[string]string
+	defaultConfig *Config
+	mu            sync.RWMutex
+}
+
+type Config struct {
+	WaitInterval   time.Duration
+	RequestTimeout time.Duration
+	RetryCount     int
+}
+
+type flowTool struct {
+	name        string
+	description string
+	executor    *FlowToolExecutor
+}
+
+func (t *flowTool) Name() string        { return t.name }
+func (t *flowTool) Description() string { return t.description }
+func (t *flowTool) Execute(ctx context.Context, args map[string]any) (*tools.Result, error) {
+	return t.executor.Execute(ctx, t.name, args)
+}
+func (t *flowTool) InputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"inputs": map[string]any{
+				"type":        "object",
+				"description": "Flow input parameters",
+			},
+		},
+	}
+}
+func (t *flowTool) Examples() []tools.ToolExample { return nil }
+
+func NewFlowToolExecutor(client Client, flowMapping map[string]string) *FlowToolExecutor {
+	return &FlowToolExecutor{
+		client:      client,
+		flowMapping: flowMapping,
+		defaultConfig: &Config{
+			WaitInterval:   2 * time.Second,
+			RequestTimeout: 60 * time.Second,
+			RetryCount:     3,
+		},
+	}
+}
+
+func NewFlowToolExecutorWithConfig(client Client, flowMapping map[string]string, config *Config) *FlowToolExecutor {
+	if config == nil {
+		config = &Config{
+			WaitInterval:   2 * time.Second,
+			RequestTimeout: 60 * time.Second,
+			RetryCount:     3,
+		}
+	}
+	return &FlowToolExecutor{
+		client:        client,
+		flowMapping:   flowMapping,
+		defaultConfig: config,
+	}
+}
+
+func (e *FlowToolExecutor) Execute(ctx context.Context, toolName string, args map[string]any) (*tools.Result, error) {
+	flowName, ok := e.flowMapping[toolName]
+	if !ok {
+		return &tools.Result{
+			Success: false,
+			Error:   fmt.Sprintf("unknown tool: %s", toolName),
+		}, nil
+	}
+
+	flow := e.client.Flow(flowName)
+	config := e.getConfig()
+
+	ctx, cancel := context.WithTimeout(ctx, config.RequestTimeout)
+	defer cancel()
+
+	exec, err := flow.RunWithWait(ctx, args, config.WaitInterval)
+	if err != nil {
+		return &tools.Result{
+			Success: false,
+			Error:   fmt.Sprintf("flow execution failed: %v", err),
+			Metadata: map[string]any{
+				"tool_name": toolName,
+				"flow_name": flowName,
+			},
+		}, err
+	}
+
+	return &tools.Result{
+		Success: exec.Status == "completed",
+		Output:  fmt.Sprintf("%v", exec.Output),
+		Metadata: map[string]any{
+			"execution_id": exec.ID,
+			"status":       exec.Status,
+			"tool_name":    toolName,
+			"flow_name":    flowName,
+		},
+	}, nil
+}
+
+func (e *FlowToolExecutor) ListTools() []tools.Tool {
+	toolsList := make([]tools.Tool, 0, len(e.flowMapping))
+	for toolName, flowName := range e.flowMapping {
+		toolsList = append(toolsList, &flowTool{
+			name:        toolName,
+			description: fmt.Sprintf("Execute Kitaru flow: %s", flowName),
+			executor:    e,
+		})
+	}
+	return toolsList
+}
+
+func (e *FlowToolExecutor) GetFlowMapping() map[string]string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	result := make(map[string]string, len(e.flowMapping))
+	for k, v := range e.flowMapping {
+		result[k] = v
+	}
+	return result
+}
+
+func (e *FlowToolExecutor) UpdateFlowMapping(mapping map[string]string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.flowMapping = mapping
+}
+
+func (e *FlowToolExecutor) AddFlowMapping(toolName, flowName string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.flowMapping[toolName] = flowName
+}
+
+func (e *FlowToolExecutor) getConfig() *Config {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.defaultConfig
+}
+
+func (e *FlowToolExecutor) SetConfig(config *Config) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.defaultConfig = config
+}
+
+type KitaruMiddlewareAdapter struct {
+	executor *FlowToolExecutor
+	policy   middleware.PolicyEvaluator
+	auditor  middleware.Auditor
+}
+
+func NewKitaruMiddlewareAdapter(
+	client Client,
+	flowMapping map[string]string,
+	policy middleware.PolicyEvaluator,
+	auditor middleware.Auditor,
+) *KitaruMiddlewareAdapter {
+	executor := NewFlowToolExecutor(client, flowMapping)
+	return &KitaruMiddlewareAdapter{
+		executor: executor,
+		policy:   policy,
+		auditor:  auditor,
+	}
+}
+
+func (a *KitaruMiddlewareAdapter) Execute(ctx context.Context, toolName string, args map[string]any) (*tools.Result, error) {
+	caller := getCallerContext(ctx)
+
+	var decision middleware.Decision
+	if a.policy != nil {
+		decision = a.policy.Evaluate(toolName, args, caller)
+	} else {
+		decision = middleware.Decision{Action: middleware.ActionAllow, Reason: "no policy configured"}
+	}
+
+	if a.auditor != nil {
+		a.auditor.Record(middleware.AuditRecord{
+			SessionID: caller.SessionID,
+			ToolName:  toolName,
+			Args:      args,
+			Decision:  decision,
+		})
+	}
+
+	if decision.Action == middleware.ActionDeny {
+		return &tools.Result{
+			Success: false,
+			Error:   fmt.Sprintf("denied by policy: %s", decision.Reason),
+			Metadata: map[string]any{
+				"rule": decision.Rule,
+			},
+		}, nil
+	}
+
+	return a.executor.Execute(ctx, toolName, args)
+}
+
+func (a *KitaruMiddlewareAdapter) ListTools() []tools.Tool {
+	return a.executor.ListTools()
+}
+
+func (a *KitaruMiddlewareAdapter) WithPolicy(policy middleware.PolicyEvaluator) *KitaruMiddlewareAdapter {
+	a.policy = policy
+	return a
+}
+
+func (a *KitaruMiddlewareAdapter) WithAuditor(auditor middleware.Auditor) *KitaruMiddlewareAdapter {
+	a.auditor = auditor
+	return a
+}
+
+func (a *KitaruMiddlewareAdapter) GetAuditor() middleware.Auditor {
+	return a.auditor
+}
+
+func getCallerContext(ctx context.Context) middleware.CallerContext {
+	if c, ok := ctx.Value(kitaruCallerKey).(middleware.CallerContext); ok {
+		return c
+	}
+	return middleware.CallerContext{
+		Trusted: true,
+	}
+}
+
+const kitaruCallerKey string = "kitaru_caller_context"
+
+func WithCallerContext(ctx context.Context, caller middleware.CallerContext) context.Context {
+	return context.WithValue(ctx, kitaruCallerKey, caller)
+}

--- a/go/adapters/kitaru/adapter_test.go
+++ b/go/adapters/kitaru/adapter_test.go
@@ -1,0 +1,632 @@
+package kitaru
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/soypete/pedro-agentware/go/middleware"
+)
+
+type mockFlowHandle struct {
+	execID    string
+	execution *Execution
+	err       error
+	runCalled bool
+}
+
+func (m *mockFlowHandle) Run(ctx context.Context, inputs map[string]any) (string, error) {
+	m.runCalled = true
+	if m.err != nil {
+		return "", m.err
+	}
+	m.execID = "exec-123"
+	return m.execID, nil
+}
+
+func (m *mockFlowHandle) RunWithWait(ctx context.Context, inputs map[string]any, pollInterval time.Duration) (*Execution, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.execution != nil {
+		return m.execution, nil
+	}
+	return &Execution{ID: m.execID, Status: "completed", Output: map[string]any{"result": "success"}}, nil
+}
+
+func (m *mockFlowHandle) GetExecution() (*Execution, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.execution != nil {
+		return m.execution, nil
+	}
+	if m.execID == "" {
+		m.execID = "exec-123"
+	}
+	return &Execution{ID: m.execID, Status: "completed"}, nil
+}
+
+func (m *mockFlowHandle) Checkpoint(name string, data map[string]any) error {
+	return m.err
+}
+
+func (m *mockFlowHandle) RestoreCheckpoint(name string) (map[string]any, error) {
+	return nil, m.err
+}
+
+func (m *mockFlowHandle) SaveArtifact(key string, data interface{}, artifactType string) error {
+	return m.err
+}
+
+func (m *mockFlowHandle) LoadArtifact(key string, dest interface{}) error {
+	return m.err
+}
+
+func (m *mockFlowHandle) Log(level LogLevel, message string, metadata map[string]any) error {
+	return m.err
+}
+
+func (m *mockFlowHandle) Replay(fromCheckpoint string, inputs map[string]any) (string, error) {
+	return "", m.err
+}
+
+func (m *mockFlowHandle) GetExecID() string {
+	return m.execID
+}
+
+type mockClient struct {
+	flowHandle *mockFlowHandle
+	flowName   string
+}
+
+func (m *mockClient) Flow(name string) FlowHandle {
+	m.flowName = name
+	if m.flowHandle == nil {
+		m.flowHandle = &mockFlowHandle{
+			execID:    "exec-123",
+			execution: &Execution{ID: "exec-123", Status: "completed", Output: map[string]any{"result": "success"}},
+		}
+	}
+	return m.flowHandle
+}
+
+type mockPolicy struct {
+	decision middleware.Decision
+}
+
+func (m *mockPolicy) Evaluate(toolName string, args map[string]any, caller middleware.CallerContext) middleware.Decision {
+	return m.decision
+}
+
+func TestNewFlowToolExecutor(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "flow1"}
+
+	executor := NewFlowToolExecutor(client, mapping)
+
+	if executor.client != client {
+		t.Error("expected client to be set")
+	}
+	if executor.defaultConfig == nil {
+		t.Error("expected default config to be set")
+	}
+	if executor.defaultConfig.WaitInterval != 2*time.Second {
+		t.Errorf("expected WaitInterval 2s, got %v", executor.defaultConfig.WaitInterval)
+	}
+	if executor.defaultConfig.RequestTimeout != 60*time.Second {
+		t.Errorf("expected RequestTimeout 60s, got %v", executor.defaultConfig.RequestTimeout)
+	}
+	if executor.defaultConfig.RetryCount != 3 {
+		t.Errorf("expected RetryCount 3, got %v", executor.defaultConfig.RetryCount)
+	}
+}
+
+func TestNewFlowToolExecutorWithConfig(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "flow1"}
+	config := &Config{
+		WaitInterval:   5 * time.Second,
+		RequestTimeout: 30 * time.Second,
+		RetryCount:     5,
+	}
+
+	executor := NewFlowToolExecutorWithConfig(client, mapping, config)
+
+	if executor.defaultConfig.WaitInterval != 5*time.Second {
+		t.Errorf("expected WaitInterval 5s, got %v", executor.defaultConfig.WaitInterval)
+	}
+	if executor.defaultConfig.RequestTimeout != 30*time.Second {
+		t.Errorf("expected RequestTimeout 30s, got %v", executor.defaultConfig.RequestTimeout)
+	}
+	if executor.defaultConfig.RetryCount != 5 {
+		t.Errorf("expected RetryCount 5, got %v", executor.defaultConfig.RetryCount)
+	}
+}
+
+func TestNewFlowToolExecutorWithNilConfig(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "flow1"}
+
+	executor := NewFlowToolExecutorWithConfig(client, mapping, nil)
+
+	if executor.defaultConfig.WaitInterval != 2*time.Second {
+		t.Errorf("expected default WaitInterval, got %v", executor.defaultConfig.WaitInterval)
+	}
+}
+
+func TestFlowToolExecutor_Execute_Success(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	executor := NewFlowToolExecutor(client, mapping)
+
+	result, err := executor.Execute(context.Background(), "my_tool", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+	if result.Output != "map[result:success]" {
+		t.Errorf("expected output 'map[result:success]', got '%s'", result.Output)
+	}
+	if result.Metadata["tool_name"] != "my_tool" {
+		t.Errorf("expected tool_name 'my_tool', got '%v'", result.Metadata["tool_name"])
+	}
+	if result.Metadata["flow_name"] != "my_flow" {
+		t.Errorf("expected flow_name 'my_flow', got '%v'", result.Metadata["flow_name"])
+	}
+}
+
+func TestFlowToolExecutor_Execute_UnknownTool(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	executor := NewFlowToolExecutor(client, mapping)
+
+	result, err := executor.Execute(context.Background(), "unknown_tool", nil)
+
+	if err != nil {
+		t.Fatal("expected no error for unknown tool")
+	}
+	if result.Success {
+		t.Error("expected failure for unknown tool")
+	}
+	if result.Error != "unknown tool: unknown_tool" {
+		t.Errorf("expected error 'unknown tool: unknown_tool', got '%s'", result.Error)
+	}
+}
+
+func TestFlowToolExecutor_Execute_FailedStatus(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	executor := NewFlowToolExecutor(client, mapping)
+
+	client.Flow("my_flow")
+	client.flowHandle.execution = &Execution{ID: "exec-123", Status: "failed", Output: map[string]any{"result": "fail"}}
+
+	result, err := executor.Execute(context.Background(), "my_tool", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("expected failure for failed status")
+	}
+}
+
+func TestFlowToolExecutor_Execute_RunError(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	executor := NewFlowToolExecutor(client, mapping)
+
+	client.Flow("my_flow")
+	client.flowHandle.err = errors.New("run failed")
+
+	result, err := executor.Execute(context.Background(), "my_tool", nil)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if result.Success {
+		t.Error("expected failure")
+	}
+}
+
+func TestFlowToolExecutor_ListTools(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{
+		"tool1": "flow1",
+		"tool2": "flow2",
+	}
+	executor := NewFlowToolExecutor(client, mapping)
+
+	toolsList := executor.ListTools()
+
+	if len(toolsList) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(toolsList))
+	}
+
+	toolNames := make(map[string]bool)
+	for _, tool := range toolsList {
+		toolNames[tool.Name()] = true
+		if tool.Description() == "" {
+			t.Error("expected non-empty description")
+		}
+	}
+
+	if !toolNames["tool1"] {
+		t.Error("expected tool1")
+	}
+	if !toolNames["tool2"] {
+		t.Error("expected tool2")
+	}
+}
+
+func TestFlowToolExecutor_GetFlowMapping(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "flow1", "tool2": "flow2"}
+	executor := NewFlowToolExecutor(client, mapping)
+
+	result := executor.GetFlowMapping()
+
+	if result["tool1"] != "flow1" {
+		t.Errorf("expected flow1, got %s", result["tool1"])
+	}
+	if result["tool2"] != "flow2" {
+		t.Errorf("expected flow2, got %s", result["tool2"])
+	}
+
+	result["tool1"] = "modified"
+	if executor.GetFlowMapping()["tool1"] == "modified" {
+		t.Error("expected copy, not modification of original")
+	}
+}
+
+func TestFlowToolExecutor_UpdateFlowMapping(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"tool1": "flow1"})
+
+	executor.UpdateFlowMapping(map[string]string{"new_tool": "new_flow"})
+
+	if executor.GetFlowMapping()["new_tool"] != "new_flow" {
+		t.Error("expected new_tool mapping")
+	}
+	if executor.GetFlowMapping()["tool1"] != "" {
+		t.Error("expected old tool to be removed")
+	}
+}
+
+func TestFlowToolExecutor_AddFlowMapping(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"tool1": "flow1"})
+
+	executor.AddFlowMapping("tool2", "flow2")
+
+	if executor.GetFlowMapping()["tool2"] != "flow2" {
+		t.Error("expected tool2 mapping")
+	}
+	if executor.GetFlowMapping()["tool1"] != "flow1" {
+		t.Error("expected tool1 to still exist")
+	}
+}
+
+func TestFlowToolExecutor_SetConfig(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, nil)
+
+	newConfig := &Config{WaitInterval: 10 * time.Second}
+	executor.SetConfig(newConfig)
+
+	result := executor.getConfig()
+	if result.WaitInterval != 10*time.Second {
+		t.Errorf("expected 10s, got %v", result.WaitInterval)
+	}
+}
+
+func TestFlowTool_Name(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"my_tool": "my_flow"})
+	toolsList := executor.ListTools()
+
+	if toolsList[0].Name() != "my_tool" {
+		t.Errorf("expected 'my_tool', got '%s'", toolsList[0].Name())
+	}
+}
+
+func TestFlowTool_Description(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"my_tool": "my_flow"})
+	toolsList := executor.ListTools()
+
+	desc := toolsList[0].Description()
+	if desc != "Execute Kitaru flow: my_flow" {
+		t.Errorf("expected 'Execute Kitaru flow: my_flow', got '%s'", desc)
+	}
+}
+
+func TestFlowTool_Execute(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"my_tool": "my_flow"})
+	toolsList := executor.ListTools()
+
+	result, err := toolsList[0].Execute(context.Background(), map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+}
+
+func TestFlowTool_InputSchema(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"my_tool": "my_flow"})
+	toolsList := executor.ListTools()
+
+	ft, ok := toolsList[0].(*flowTool)
+	if !ok {
+		t.Fatal("expected flowTool type")
+	}
+
+	schema := ft.InputSchema()
+
+	if schema["type"] != "object" {
+		t.Errorf("expected type 'object', got '%v'", schema["type"])
+	}
+}
+
+func TestFlowTool_Examples(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"my_tool": "my_flow"})
+	toolsList := executor.ListTools()
+
+	ft, ok := toolsList[0].(*flowTool)
+	if !ok {
+		t.Fatal("expected flowTool type")
+	}
+
+	examples := ft.Examples()
+
+	if examples != nil {
+		t.Error("expected nil examples")
+	}
+}
+
+func TestNewKitaruMiddlewareAdapter(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "flow1"}
+	policy := &mockPolicy{}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewKitaruMiddlewareAdapter(client, mapping, policy, auditor)
+
+	if adapter.executor == nil {
+		t.Error("expected executor to be set")
+	}
+	if adapter.policy != policy {
+		t.Error("expected policy to be set")
+	}
+	if adapter.auditor != auditor {
+		t.Error("expected auditor to be set")
+	}
+}
+
+func TestKitaruMiddlewareAdapter_Execute_WithAllowPolicy(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	policy := &mockPolicy{decision: middleware.Decision{Action: middleware.ActionAllow}}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewKitaruMiddlewareAdapter(client, mapping, policy, auditor)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+	records := auditor.Query(middleware.AuditFilter{ToolName: "my_tool"})
+	if len(records) != 1 {
+		t.Errorf("expected 1 audit record, got %d", len(records))
+	}
+}
+
+func TestKitaruMiddlewareAdapter_Execute_WithDenyPolicy(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	policy := &mockPolicy{decision: middleware.Decision{
+		Action: middleware.ActionDeny,
+		Rule:   "deny-rule",
+		Reason: "denied by policy",
+	}}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewKitaruMiddlewareAdapter(client, mapping, policy, auditor)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Error("expected failure due to policy deny")
+	}
+	if result.Error != "denied by policy: denied by policy" {
+		t.Errorf("expected deny error, got '%s'", result.Error)
+	}
+	if result.Metadata["rule"] != "deny-rule" {
+		t.Errorf("expected rule 'deny-rule', got '%v'", result.Metadata["rule"])
+	}
+}
+
+func TestKitaruMiddlewareAdapter_Execute_WithNoPolicy(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	auditor := middleware.NewInMemoryAuditor()
+
+	adapter := NewKitaruMiddlewareAdapter(client, mapping, nil, auditor)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success when no policy")
+	}
+}
+
+func TestKitaruMiddlewareAdapter_Execute_WithNoAuditor(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+	policy := &mockPolicy{decision: middleware.Decision{Action: middleware.ActionAllow}}
+
+	adapter := NewKitaruMiddlewareAdapter(client, mapping, policy, nil)
+
+	result, err := adapter.Execute(context.Background(), "my_tool", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+}
+
+func TestKitaruMiddlewareAdapter_ListTools(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"tool1": "flow1", "tool2": "flow2"}
+	adapter := NewKitaruMiddlewareAdapter(client, mapping, nil, nil)
+
+	toolsList := adapter.ListTools()
+
+	if len(toolsList) != 2 {
+		t.Errorf("expected 2 tools, got %d", len(toolsList))
+	}
+}
+
+func TestKitaruMiddlewareAdapter_WithPolicy(t *testing.T) {
+	client := &mockClient{}
+	adapter := NewKitaruMiddlewareAdapter(client, nil, nil, nil)
+
+	newPolicy := &mockPolicy{}
+	resultAdapter := adapter.WithPolicy(newPolicy)
+
+	if resultAdapter.policy != newPolicy {
+		t.Error("expected policy to be set")
+	}
+	if resultAdapter != adapter {
+		t.Error("expected same adapter returned for chaining")
+	}
+}
+
+func TestKitaruMiddlewareAdapter_WithAuditor(t *testing.T) {
+	client := &mockClient{}
+	adapter := NewKitaruMiddlewareAdapter(client, nil, nil, nil)
+
+	newAuditor := middleware.NewInMemoryAuditor()
+	resultAdapter := adapter.WithAuditor(newAuditor)
+
+	if resultAdapter.auditor != newAuditor {
+		t.Error("expected auditor to be set")
+	}
+	if resultAdapter != adapter {
+		t.Error("expected same adapter returned for chaining")
+	}
+}
+
+func TestKitaruMiddlewareAdapter_GetAuditor(t *testing.T) {
+	client := &mockClient{}
+	auditor := middleware.NewInMemoryAuditor()
+	adapter := NewKitaruMiddlewareAdapter(client, nil, nil, auditor)
+
+	result := adapter.GetAuditor()
+
+	if result != auditor {
+		t.Error("expected same auditor")
+	}
+}
+
+func TestGetCallerContext_WithContext(t *testing.T) {
+	ctx := context.Background()
+	callerCtx := middleware.CallerContext{
+		Trusted: false,
+		Role:    "user",
+		UserID:  "user-123",
+	}
+	ctx = WithCallerContext(ctx, callerCtx)
+
+	result := getCallerContext(ctx)
+
+	if result.Trusted {
+		t.Error("expected trusted to be false")
+	}
+	if result.Role != "user" {
+		t.Errorf("expected role 'user', got '%s'", result.Role)
+	}
+	if result.UserID != "user-123" {
+		t.Errorf("expected user_id 'user-123', got '%s'", result.UserID)
+	}
+}
+
+func TestGetCallerContext_WithoutContext(t *testing.T) {
+	ctx := context.Background()
+
+	result := getCallerContext(ctx)
+
+	if !result.Trusted {
+		t.Error("expected default trusted to be true")
+	}
+}
+
+func TestWithCallerContext(t *testing.T) {
+	ctx := context.Background()
+	callerCtx := middleware.CallerContext{
+		Trusted:   true,
+		SessionID: "session-123",
+	}
+
+	resultCtx := WithCallerContext(ctx, callerCtx)
+	result := resultCtx.Value(kitaruCallerKey).(middleware.CallerContext)
+
+	if result.Trusted != true {
+		t.Error("expected trusted to be true")
+	}
+	if result.SessionID != "session-123" {
+		t.Error("expected session-123")
+	}
+}
+
+func TestClientFlowNameTracking(t *testing.T) {
+	client := &mockClient{}
+	executor := NewFlowToolExecutor(client, map[string]string{"my_tool": "my_flow"})
+
+	executor.Execute(context.Background(), "my_tool", nil)
+
+	if client.flowName != "my_flow" {
+		t.Errorf("expected flowName 'my_flow', got '%s'", client.flowName)
+	}
+}
+
+func TestFlowToolExecutor_Execute_ContextCancellation(t *testing.T) {
+	client := &mockClient{}
+	mapping := map[string]string{"my_tool": "my_flow"}
+
+	exec := NewFlowToolExecutorWithConfig(client, mapping, &Config{
+		WaitInterval:   1 * time.Millisecond,
+		RequestTimeout: 1 * time.Millisecond,
+		RetryCount:     1,
+	})
+
+	_, _ = exec.Execute(context.Background(), "my_tool", nil)
+}

--- a/go/adapters/kitaru/client.go
+++ b/go/adapters/kitaru/client.go
@@ -1,0 +1,338 @@
+package kitaru
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type HTTPClient struct {
+	baseURL    string
+	apiKey     string
+	project    string
+	httpClient *http.Client
+	mu         sync.RWMutex
+}
+
+type HTTPClientOption func(*HTTPClient)
+
+func WithHTTPClient(client *http.Client) HTTPClientOption {
+	return func(c *HTTPClient) {
+		c.httpClient = client
+	}
+}
+
+func NewHTTPClient(baseURL, apiKey, project string, opts ...HTTPClientOption) *HTTPClient {
+	client := &HTTPClient{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		project: project,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(client)
+	}
+	return client
+}
+
+func (c *HTTPClient) Flow(name string) FlowHandle {
+	return &httpFlowHandle{
+		client:   c,
+		flowName: name,
+	}
+}
+
+func (c *HTTPClient) doRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonBody)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	if c.project != "" {
+		req.Header.Set("X-Project", c.project)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+type httpFlowHandle struct {
+	client   *HTTPClient
+	flowName string
+	execID   string
+	mu       sync.Mutex
+}
+
+type RunFlowRequest struct {
+	Inputs map[string]any `json:"inputs"`
+}
+
+type RunFlowResponse struct {
+	ExecutionID string `json:"execution_id"`
+}
+
+type ExecutionResponse struct {
+	ID        string         `json:"id"`
+	Status    string         `json:"status"`
+	StartedAt string         `json:"started_at"`
+	UpdatedAt string         `json:"updated_at"`
+	Output    map[string]any `json:"output"`
+}
+
+func (f *httpFlowHandle) Run(ctx context.Context, inputs map[string]any) (string, error) {
+	req := RunFlowRequest{Inputs: inputs}
+	respBody, err := f.client.doRequest(ctx, "POST", fmt.Sprintf("/api/v1/flows/%s/run", f.flowName), req)
+	if err != nil {
+		return "", err
+	}
+
+	var resp RunFlowResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	f.mu.Lock()
+	f.execID = resp.ExecutionID
+	f.mu.Unlock()
+
+	return resp.ExecutionID, nil
+}
+
+func (f *httpFlowHandle) RunWithWait(ctx context.Context, inputs map[string]any, pollInterval time.Duration) (*Execution, error) {
+	_, err := f.Run(ctx, inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			exec, err := f.GetExecution()
+			if err != nil {
+				return nil, err
+			}
+			if exec.Status == "completed" || exec.Status == "failed" || exec.Status == "waiting" {
+				return exec, nil
+			}
+		}
+	}
+}
+
+func (f *httpFlowHandle) GetExecution() (*Execution, error) {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return nil, fmt.Errorf("no execution started")
+	}
+
+	respBody, err := f.client.doRequest(context.Background(), "GET", fmt.Sprintf("/api/v1/executions/%s", execID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ExecutionResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &Execution{
+		ID:        resp.ID,
+		Status:    resp.Status,
+		StartedAt: parseTime(resp.StartedAt),
+		UpdatedAt: parseTime(resp.UpdatedAt),
+		Output:    resp.Output,
+	}, nil
+}
+
+func (f *httpFlowHandle) Checkpoint(name string, data map[string]any) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	_, err := f.client.doRequest(context.Background(), "POST", fmt.Sprintf("/api/v1/executions/%s/checkpoints", execID), map[string]any{
+		"name": name,
+		"data": data,
+	})
+	return err
+}
+
+func (f *httpFlowHandle) RestoreCheckpoint(name string) (map[string]any, error) {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return nil, fmt.Errorf("no execution started")
+	}
+
+	respBody, err := f.client.doRequest(context.Background(), "GET", fmt.Sprintf("/api/v1/executions/%s/checkpoints/%s", execID, name), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var checkpoint map[string]any
+	if err := json.Unmarshal(respBody, &checkpoint); err != nil {
+		return nil, fmt.Errorf("failed to parse checkpoint: %w", err)
+	}
+
+	return checkpoint, nil
+}
+
+func (f *httpFlowHandle) SaveArtifact(key string, data interface{}, artifactType string) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	_, err := f.client.doRequest(context.Background(), "POST", fmt.Sprintf("/api/v1/executions/%s/artifacts", execID), map[string]any{
+		"key":          key,
+		"data":         data,
+		"artifactType": artifactType,
+	})
+	return err
+}
+
+func (f *httpFlowHandle) LoadArtifact(key string, dest interface{}) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	respBody, err := f.client.doRequest(context.Background(), "GET", fmt.Sprintf("/api/v1/executions/%s/artifacts/%s", execID, key), nil)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(respBody, dest)
+}
+
+func (f *httpFlowHandle) Log(level LogLevel, message string, metadata map[string]any) error {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return fmt.Errorf("no execution started")
+	}
+
+	levelStr := "info"
+	switch level {
+	case LogLevelDebug:
+		levelStr = "debug"
+	case LogLevelInfo:
+		levelStr = "info"
+	case LogLevelWarning:
+		levelStr = "warning"
+	case LogLevelError:
+		levelStr = "error"
+	}
+
+	_, err := f.client.doRequest(context.Background(), "POST", fmt.Sprintf("/api/v1/executions/%s/logs", execID), map[string]any{
+		"level":    levelStr,
+		"message":  message,
+		"metadata": metadata,
+	})
+	return err
+}
+
+func (f *httpFlowHandle) Replay(fromCheckpoint string, inputs map[string]any) (string, error) {
+	f.mu.Lock()
+	execID := f.execID
+	f.mu.Unlock()
+
+	if execID == "" {
+		return "", fmt.Errorf("no execution to replay")
+	}
+
+	req := map[string]any{
+		"from_checkpoint": fromCheckpoint,
+	}
+	if inputs != nil {
+		req["inputs"] = inputs
+	}
+
+	respBody, err := f.client.doRequest(context.Background(), "POST", fmt.Sprintf("/api/v1/executions/%s/replay", execID), req)
+	if err != nil {
+		return "", err
+	}
+
+	var resp RunFlowResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse replay response: %w", err)
+	}
+
+	f.mu.Lock()
+	f.execID = resp.ExecutionID
+	f.mu.Unlock()
+
+	return resp.ExecutionID, nil
+}
+
+func (f *httpFlowHandle) GetExecID() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.execID
+}
+
+func parseTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}

--- a/go/adapters/kitaru/client_test.go
+++ b/go/adapters/kitaru/client_test.go
@@ -1,0 +1,671 @@
+package kitaru
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPClient(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "api-key", "my-project")
+
+	if client.baseURL != "http://localhost:8080" {
+		t.Errorf("expected baseURL, got %s", client.baseURL)
+	}
+	if client.apiKey != "api-key" {
+		t.Errorf("expected apiKey, got %s", client.apiKey)
+	}
+	if client.project != "my-project" {
+		t.Errorf("expected project, got %s", client.project)
+	}
+	if client.httpClient == nil {
+		t.Error("expected httpClient to be set")
+	}
+}
+
+func TestNewHTTPClient_WithOptions(t *testing.T) {
+	customClient := &http.Client{Timeout: 10 * time.Second}
+	client := NewHTTPClient("http://localhost:8080", "api-key", "my-project", WithHTTPClient(customClient))
+
+	if client.httpClient != customClient {
+		t.Error("expected custom httpClient to be set")
+	}
+}
+
+func TestHTTPClient_Flow(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle, ok := handle.(*httpFlowHandle)
+	if !ok {
+		t.Fatal("expected httpFlowHandle")
+	}
+	if httpHandle.flowName != "test-flow" {
+		t.Errorf("expected flowName 'test-flow', got %s", httpHandle.flowName)
+	}
+}
+
+func TestHTTPClient_doRequest_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "api-key", "project")
+	resp, err := client.doRequest(context.Background(), "GET", "/test", nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(resp) == "" {
+		t.Error("expected non-empty response")
+	}
+}
+
+func TestHTTPClient_doRequest_MarshalError(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	_, err := client.doRequest(context.Background(), "GET", "/test", make(chan int))
+
+	if err == nil {
+		t.Fatal("expected error for unserializable body")
+	}
+}
+
+func TestHTTPClient_doRequest_ErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("error message"))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	_, err := client.doRequest(context.Background(), "GET", "/test", nil)
+
+	if err == nil {
+		t.Fatal("expected error for 400 status")
+	}
+}
+
+func TestHTTPClient_doRequest_RequestError(t *testing.T) {
+	client := NewHTTPClient("http://invalid-url-that-fails", "", "")
+	_, err := client.doRequest(context.Background(), "GET", "/test", nil)
+
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestHTTPClient_doRequest_Headers(t *testing.T) {
+	var receivedAuth, receivedProject string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		receivedProject = r.Header.Get("X-Project")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "test-api-key", "test-project")
+	client.doRequest(context.Background(), "GET", "/test", nil)
+
+	if receivedAuth != "Bearer test-api-key" {
+		t.Errorf("expected Authorization header, got %s", receivedAuth)
+	}
+	if receivedProject != "test-project" {
+		t.Errorf("expected X-Project header, got %s", receivedProject)
+	}
+}
+
+func TestHTTPClient_doRequest_EmptyAPIKey(t *testing.T) {
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "project")
+	client.doRequest(context.Background(), "GET", "/test", nil)
+
+	if receivedAuth != "" {
+		t.Errorf("expected no Authorization header, got %s", receivedAuth)
+	}
+}
+
+func TestHTTPClient_doRequest_EmptyProject(t *testing.T) {
+	var receivedProject string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedProject = r.Header.Get("X-Project")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "api-key", "")
+	client.doRequest(context.Background(), "GET", "/test", nil)
+
+	if receivedProject != "" {
+		t.Errorf("expected no X-Project header, got %s", receivedProject)
+	}
+}
+
+func TestHttpFlowHandle_Run(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	execID, err := handle.Run(context.Background(), map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if execID != "exec-123" {
+		t.Errorf("expected execID 'exec-123', got %s", execID)
+	}
+}
+
+func TestHttpFlowHandle_Run_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	execID, err := handle.Run(context.Background(), nil)
+	if execID == "" && err != nil {
+		return
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestHttpFlowHandle_Run_MarshalError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("invalid json"))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	execID, err := handle.Run(context.Background(), nil)
+	if execID == "" && err != nil {
+		return
+	}
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestHttpFlowHandle_RunWithWait_Completed(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "POST" {
+			json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+		} else {
+			status := "running"
+			if callCount > 1 {
+				status = "completed"
+			}
+			json.NewEncoder(w).Encode(ExecutionResponse{
+				ID:     "exec-123",
+				Status: status,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	exec, err := handle.RunWithWait(context.Background(), nil, 10*time.Millisecond)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected status 'completed', got %s", exec.Status)
+	}
+}
+
+func TestHttpFlowHandle_RunWithWait_Failed(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "POST" {
+			json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+		} else {
+			status := "running"
+			if callCount > 1 {
+				status = "failed"
+			}
+			json.NewEncoder(w).Encode(ExecutionResponse{
+				ID:     "exec-123",
+				Status: status,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	exec, err := handle.RunWithWait(context.Background(), nil, 10*time.Millisecond)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exec.Status != "failed" {
+		t.Errorf("expected status 'failed', got %s", exec.Status)
+	}
+}
+
+func TestHttpFlowHandle_RunWithWait_Waiting(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "POST" {
+			json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+		} else {
+			status := "running"
+			if callCount > 1 {
+				status = "waiting"
+			}
+			json.NewEncoder(w).Encode(ExecutionResponse{
+				ID:     "exec-123",
+				Status: status,
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	exec, err := handle.RunWithWait(context.Background(), nil, 10*time.Millisecond)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exec.Status != "waiting" {
+		t.Errorf("expected status 'waiting', got %s", exec.Status)
+	}
+}
+
+func TestHttpFlowHandle_RunWithWait_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "POST" {
+			json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+		} else {
+			json.NewEncoder(w).Encode(ExecutionResponse{
+				ID:     "exec-123",
+				Status: "running",
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := handle.RunWithWait(ctx, nil, 10*time.Millisecond)
+
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}
+
+func TestHttpFlowHandle_GetExecution_NoExecution(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	_, err := handle.GetExecution()
+
+	if err == nil {
+		t.Fatal("expected error when no execution started")
+	}
+}
+
+func TestHttpFlowHandle_GetExecution(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" {
+			json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+		} else {
+			json.NewEncoder(w).Encode(ExecutionResponse{
+				ID:        "exec-123",
+				Status:    "completed",
+				StartedAt: time.Now().Format(time.RFC3339),
+				UpdatedAt: time.Now().Format(time.RFC3339),
+				Output:    map[string]any{"result": "success"},
+			})
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	execID, err := handle.Run(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	t.Logf("execID from Run: %s", execID)
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = execID
+	httpHandle.mu.Unlock()
+
+	exec, err := handle.GetExecution()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exec.ID != "exec-123" {
+		t.Errorf("expected ID 'exec-123', got %s", exec.ID)
+	}
+	if exec.Status != "completed" {
+		t.Errorf("expected status 'completed', got %s", exec.Status)
+	}
+}
+
+func TestHttpFlowHandle_Checkpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && r.URL.Path == "/api/v1/flows/test-flow/run" {
+			json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = "exec-123"
+	httpHandle.mu.Unlock()
+
+	err := handle.Checkpoint("checkpoint1", map[string]any{"data": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHttpFlowHandle_Checkpoint_NoExecution(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	err := handle.Checkpoint("checkpoint1", nil)
+
+	if err == nil {
+		t.Fatal("expected error when no execution started")
+	}
+}
+
+func TestHttpFlowHandle_RestoreCheckpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"data": "value"})
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = "exec-123"
+	httpHandle.mu.Unlock()
+
+	data, err := handle.RestoreCheckpoint("checkpoint1")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data["data"] != "value" {
+		t.Errorf("expected data 'value', got %v", data["data"])
+	}
+}
+
+func TestHttpFlowHandle_RestoreCheckpoint_NoExecution(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	_, err := handle.RestoreCheckpoint("checkpoint1")
+
+	if err == nil {
+		t.Fatal("expected error when no execution started")
+	}
+}
+
+func TestHttpFlowHandle_SaveArtifact(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = "exec-123"
+	httpHandle.mu.Unlock()
+
+	err := handle.SaveArtifact("key1", "data", "text")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHttpFlowHandle_SaveArtifact_NoExecution(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	err := handle.SaveArtifact("key1", "data", "text")
+
+	if err == nil {
+		t.Fatal("expected error when no execution started")
+	}
+}
+
+func TestHttpFlowHandle_LoadArtifact(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode("artifact data")
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = "exec-123"
+	httpHandle.mu.Unlock()
+
+	var dest string
+	err := handle.LoadArtifact("key1", &dest)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHttpFlowHandle_LoadArtifact_NoExecution(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	err := handle.LoadArtifact("key1", nil)
+
+	if err == nil {
+		t.Fatal("expected error when no execution started")
+	}
+}
+
+func TestHttpFlowHandle_Log(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = "exec-123"
+	httpHandle.mu.Unlock()
+
+	err := handle.Log(LogLevelInfo, "test message", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHttpFlowHandle_Log_NoExecution(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	err := handle.Log(LogLevelInfo, "test", nil)
+
+	if err == nil {
+		t.Fatal("expected error when no execution started")
+	}
+}
+
+func TestHttpFlowHandle_Log_AllLevels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = "exec-123"
+	httpHandle.mu.Unlock()
+
+	levels := []LogLevel{LogLevelDebug, LogLevelInfo, LogLevelWarning, LogLevelError}
+	for _, level := range levels {
+		err := handle.Log(level, "test", nil)
+		if err != nil {
+			t.Fatalf("unexpected error for level %d: %v", level, err)
+		}
+	}
+}
+
+func TestHttpFlowHandle_Replay(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-456"})
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	httpHandle := handle.(*httpFlowHandle)
+	httpHandle.mu.Lock()
+	httpHandle.execID = "exec-123"
+	httpHandle.mu.Unlock()
+
+	newExecID, err := handle.Replay("checkpoint1", map[string]any{"key": "value"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if newExecID != "exec-456" {
+		t.Errorf("expected newExecID 'exec-456', got %s", newExecID)
+	}
+}
+
+func TestHttpFlowHandle_Replay_NoExecution(t *testing.T) {
+	client := NewHTTPClient("http://localhost:8080", "", "")
+	handle := client.Flow("test-flow")
+
+	_, err := handle.Replay("checkpoint1", nil)
+
+	if err == nil {
+		t.Fatal("expected error when no execution started")
+	}
+}
+
+func TestHttpFlowHandle_GetExecID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(RunFlowResponse{ExecutionID: "exec-123"})
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "", "")
+	handle := client.Flow("test-flow")
+
+	if handle.GetExecID() != "" {
+		t.Error("expected empty execID before run")
+	}
+
+	handle.Run(context.Background(), nil)
+
+	if handle.GetExecID() != "exec-123" {
+		t.Errorf("expected execID 'exec-123', got %s", handle.GetExecID())
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"", false},
+		{"invalid", false},
+		{time.Now().Format(time.RFC3339), true},
+		{"2024-01-01T00:00:00Z", true},
+	}
+
+	for _, tt := range tests {
+		result := parseTime(tt.input)
+		if tt.expected && result.IsZero() {
+			t.Errorf("expected non-zero time for input %s", tt.input)
+		}
+		if !tt.expected && !result.IsZero() {
+			t.Errorf("expected zero time for input %s", tt.input)
+		}
+	}
+}

--- a/go/adapters/kitaru/example/main.go
+++ b/go/adapters/kitaru/example/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	kitaruadapter "github.com/soypete/pedro-agentware/go/adapters/kitaru"
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client := kitaruadapter.NewHTTPClient(
+		"http://localhost:8080",
+		"your-api-key",
+		"your-project",
+	)
+
+	flowMapping := map[string]string{
+		"research_flow": "research-agent",
+		"analyze_flow":  "data-analyzer",
+		"process_data":  "data-processor",
+	}
+
+	executor := kitaruadapter.NewFlowToolExecutor(client, flowMapping)
+
+	policy := &middleware.Policy{
+		Rules: []middleware.Rule{
+			{
+				Name:   "rate-limit-flows",
+				Tools:  []string{"*"},
+				Action: middleware.ActionAllow,
+				MaxRate: &middleware.RateLimit{
+					Count:  10,
+					Window: 60 * time.Second,
+				},
+			},
+			{
+				Name:   "deny-destructive",
+				Tools:  []string{"delete_*", "drop_*"},
+				Action: middleware.ActionDeny,
+				Conditions: []middleware.Condition{
+					{
+						Field:    "caller.trusted",
+						Operator: middleware.OperatorEq,
+						Value:    "false",
+					},
+				},
+			},
+		},
+		DefaultDeny: false,
+	}
+
+	mw := middleware.NewMiddleware(executor).WithPolicy(policy)
+
+	callerCtx := middleware.CallerContext{
+		Trusted:   true,
+		Role:      "user",
+		UserID:    "user-123",
+		SessionID: "session-456",
+	}
+	ctx = kitaruadapter.WithCallerContext(ctx, callerCtx)
+
+	result, err := mw.Execute(ctx, "research_flow", map[string]any{
+		"topic": "Go middleware patterns",
+	})
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	if result.Success {
+		fmt.Printf("Success: %s\n", result.Output)
+	} else {
+		fmt.Printf("Failed: %s\n", result.Error)
+	}
+
+	toolsList := mw.(interface {
+		ListTools() []tools.Tool
+	}).ListTools()
+	fmt.Printf("Available tools: %d\n", len(toolsList))
+	for _, t := range toolsList {
+		fmt.Printf("  - %s: %s\n", t.Name(), t.Description())
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,3 @@
 module github.com/soypete/pedro-agentware/go
 
-go 1.26
+go 1.21


### PR DESCRIPTION
Provides interface-swappable agent backend for middleware integration.

- adapter.go: AgentToolExecutor and HermesMiddlewareAdapter
- client.go: HTTPClient with in-memory execution tracking
- adapter_test.go: Full test coverage