### PR TITLE
Add tools support and thinking to inference executor

### DIFF
--- a/go/executor/executor.go
+++ b/go/executor/executor.go
@@ -35,6 +35,8 @@ type ExecuteRequest struct {
 	CallerCtx middleware.CallerContext
 	// JobID is an optional identifier for correlating logs and context files.
 	JobID string
+	// Thinking enables extended thinking/reasoning for the model.
+	Thinking bool
 }
 
 // ExecuteResult is the output of a completed (or terminated) agent run.

--- a/go/executor/inference.go
+++ b/go/executor/inference.go
@@ -34,10 +34,32 @@ func (e *inferenceExecutor) Execute(ctx context.Context, req ExecuteRequest) (*E
 		default:
 		}
 
+		toolsList := e.config.Registry.All()
+		llmTools := make([]llm.ToolDefinition, 0, len(toolsList))
+		for _, t := range toolsList {
+			inputSchema := map[string]any{}
+			if ext, ok := t.(interface{ InputSchema() map[string]any }); ok {
+				inputSchema = ext.InputSchema()
+			}
+			llmTools = append(llmTools, llm.ToolDefinition{
+				Name:        t.Name(),
+				Description: t.Description(),
+				InputSchema: inputSchema,
+			})
+		}
+
 		llmReq := &llm.Request{
 			Messages:    conversation,
 			Temperature: 0.7,
 			MaxTokens:   4096,
+			Tools:       llmTools,
+		}
+
+		if req.Thinking {
+			llmReq.Thinking = &llm.ThinkingConfig{
+				Type:      "enabled",
+				MaxTokens: 8192,
+			}
 		}
 
 		resp, err := e.config.Backend.Complete(ctx, llmReq)

--- a/go/llm/request.go
+++ b/go/llm/request.go
@@ -30,6 +30,12 @@ type Request struct {
 	Temperature float64
 	MaxTokens   int
 	Stop        []string
+	Thinking    *ThinkingConfig
+}
+
+type ThinkingConfig struct {
+	Type      string
+	MaxTokens int
 }
 
 // Message is a single turn in a conversation.

--- a/go/llm/server.go
+++ b/go/llm/server.go
@@ -59,6 +59,13 @@ func (b *serverBackend) Complete(ctx context.Context, req *Request) (*Response, 
 		payload["tools"] = tools
 	}
 
+	if req.Thinking != nil {
+		payload["thinking"] = map[string]any{
+			"type":       req.Thinking.Type,
+			"max_tokens": req.Thinking.MaxTokens,
+		}
+	}
+
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)


### PR DESCRIPTION
Cherry-pick of commit 5384935 from feature/kitaru-integration.

- Fix: Tools from registry are now sent to LLM in inference loop
- Add: ThinkingConfig for extended thinking/reasoning support
- Add: Thinking field in ExecuteRequest to enable per-request

This fixes tool calling and enables models that support thinking.