### PR TITLE
feat: ontology-constrained wiki memory (per-user, enforced, with claim confidence)

### DIFF
--- a/.github/workflows/memory-e2e.yml
+++ b/.github/workflows/memory-e2e.yml
@@ -1,0 +1,79 @@
+name: Wiki Memory E2E
+
+# Fresh clone -> enable memory -> ingest -> infer -> query, across all
+# three SDK surfaces (Go core, Python client + inference, TS client).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'go/**'
+      - 'python/**'
+      - 'typescript/**'
+      - 'ontologies'
+      - '.github/workflows/memory-e2e.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'go/**'
+      - 'python/**'
+      - 'typescript/**'
+      - 'ontologies'
+      - '.github/workflows/memory-e2e.yml'
+
+jobs:
+  memory-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Go core tests (memory, ontology, page, mcp)
+        run: |
+          cd go
+          go vet ./...
+          go test ./...
+
+      - name: Build memctl
+        run: |
+          cd go
+          go build -o "$RUNNER_TEMP/memctl" ./cmd/memctl
+          echo "PEDRO_MEMCTL=$RUNNER_TEMP/memctl" >> "$GITHUB_ENV"
+
+      - name: Lint example vault stays enforceable
+        run: |
+          mkdir -p /tmp/e2e-vault/wiki
+          printf -- '---\nid: goroutines\ntype: sw:Skill\nlabels: ["Goroutines"]\ntopics: [twitch:Go]\n---\n' \
+            > /tmp/e2e-vault/wiki/goroutines.md
+          "$PEDRO_MEMCTL" lint \
+            -tbox ontologies/education/TBOX_LEARNING_SOFTWARE.ttl \
+            -tbox ontologies/social/twitch_topics.ttl \
+            /tmp/e2e-vault/wiki
+
+      - name: Python SDK tests (client, inference, dogfood e2e)
+        run: |
+          cd python
+          uv venv --python 3.12 .venv
+          uv pip install --python .venv/bin/python -e ".[dev,inference]"
+          .venv/bin/python -m pytest tests/ -q
+
+      - name: Dogfood end-to-end (enable -> ingest -> deny/retry -> infer -> query)
+        run: |
+          cd python
+          .venv/bin/python examples/wiki_memory_dogfood.py
+
+      - name: TypeScript SDK tests (incl. cross-SDK isolation)
+        run: |
+          cd typescript
+          npm ci
+          npm run build
+          npm test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ontologies"]
+	path = ontologies
+	url = https://github.com/Soypete/ontologies

--- a/BLOCKERS.md
+++ b/BLOCKERS.md
@@ -1,0 +1,15 @@
+# Wiki Memory — Blockers
+
+Active blockers and how they were routed around. Resolved items move to the
+bottom.
+
+## Watching (not blocking)
+
+- **ontology-go PR #18 pending merge.**
+  `validate.checkInconsistentHierarchy` had an inverted direction check
+  (flagged consistent inverse pairs, missed real broader+narrower
+  contradictions). Fix + regression tests submitted upstream:
+  https://github.com/Soypete/ontology-go/pull/18. Until merge, `go/go.mod`
+  pins the canonical module at the PR commit
+  (`v0.0.0-20260730165556-4c8e635acec4`) — same module path, no fork or
+  vendor patch. After merge: re-pin to main and delete this entry.

--- a/BLOCKERS.md
+++ b/BLOCKERS.md
@@ -5,18 +5,13 @@ bottom.
 
 ## Watching (not blocking)
 
-- **No MCP server package in agentware yet.** `business/SDK_PLAN.md`
-  specifies an `mcp/` package (stdio + HTTP transports) that doesn't exist;
-  memory tools are currently exposed via `tools.ToolRegistry` and
-  `WikiMemory.RegisterTools`. The SDK-facing MCP exposure lands with the
-  Python/TS client phases; if the mcp package is still absent then, build
-  the minimal server as part of that work rather than forking the plan.
+(none)
 
-- **ontology-go PR #18 pending merge.**
-  `validate.checkInconsistentHierarchy` had an inverted direction check
-  (flagged consistent inverse pairs, missed real broader+narrower
-  contradictions). Fix + regression tests submitted upstream:
-  https://github.com/Soypete/ontology-go/pull/18. Until merge, `go/go.mod`
-  pins the canonical module at the PR commit
-  (`v0.0.0-20260730165556-4c8e635acec4`) — same module path, no fork or
-  vendor patch. After merge: re-pin to main and delete this entry.
+## Resolved
+
+- **ontology-go PR #18** (inverted inconsistent-hierarchy check) —
+  merged 2026-07-30; `go/go.mod` re-pinned to main
+  (`v0.0.0-20260730193222-0c5ba6ae2cd5`), all tests green.
+- **No MCP server package in agentware** — resolved by `go/mcp` (stdio
+  JSON-RPC 2.0 server) + `memctl serve`; both SDKs consume it. HTTP+SSE
+  transport remains future work (see REPORT.md v2 recommendations).

--- a/BLOCKERS.md
+++ b/BLOCKERS.md
@@ -5,6 +5,13 @@ bottom.
 
 ## Watching (not blocking)
 
+- **No MCP server package in agentware yet.** `business/SDK_PLAN.md`
+  specifies an `mcp/` package (stdio + HTTP transports) that doesn't exist;
+  memory tools are currently exposed via `tools.ToolRegistry` and
+  `WikiMemory.RegisterTools`. The SDK-facing MCP exposure lands with the
+  Python/TS client phases; if the mcp package is still absent then, build
+  the minimal server as part of that work rather than forking the plan.
+
 - **ontology-go PR #18 pending merge.**
   `validate.checkInconsistentHierarchy` had an inverted direction check
   (flagged consistent inverse pairs, missed real broader+narrower

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,13 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 1.1 page parser → A-box | DONE
+`go/memory/page`: YAML frontmatter parser (strict fields, kebab-case ids,
+CURIE types/preds, unique claim ids), typed-wikilink extraction
+(`[[t|pred=...]]` + bare → skos:related), A-box emission as N-Triples.
+Mid-iteration pivot on maintainer direction: RDF layer switched from
+knakk/rdf to `github.com/soypete/ontology-go` (D5 in DECISIONS.md) — its
+validate/reasoner packages also cover much of task 1.2. Tests green.
+
 ## [2026-07-30] 0.2 skeleton + vault + schema | DONE
 Added `ontologies/` submodule, `go/memory/` package (doc.go + Vault with
 per-user layout, kebab-case page ids, and path-boundary containment —

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,19 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 3.2 pgmpy inference engine + JSON contract | DONE
+Contract at go/memory/infer/schema.json (one schema for subprocess and
+future MCP transports). Engine at pedro_agentware.memory.infer (pgmpy
+DiscreteMarkovNetwork; 'inference' extra; runnable via python -m for the
+Go subprocess transport): binary claim/source nodes, agreement/
+disagreement potentials (supports 0.8, contradicts 0.9, sourceOf 0.85),
+source priors 0.7 default / 0.4 superseded, BP first with Gibbs fallback,
+contested = contradicts edge vs claim above 0.6. Tuned sourceOf from 0.7
+to 0.85 after numeric probing (mutual-support case peaked at 0.74
+otherwise); edge-less sources dropped so BP's junction tree stays
+connected. Spec tests: mutual 0.877 (>0.85), superseded+contradicted
+0.223 (<0.5, contested), cycle exact via BP. Full python suite 118 pass
+(pytest -p pytest_asyncio.plugin under uv py3.12 venv).
+
 ## [2026-07-30] 3.1 Python SDK WikiMemory + LangGraph tools | DONE
 `pedro_agentware.memory`: WikiMemory spawns `memctl serve` per user (MCP
 stdio, per SDK plan subprocess mode), implements the SDK's ToolExecutor

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,15 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 2.1 OntologyEvaluator + declarative policy | DONE
+`go/memory`: two-tier evaluator implementing middleware.PolicyEvaluator —
+tier 1 embedded policy.yaml (deny-by-default, scope-override + anonymous
+denies, per-user+tool rate limits via middleware.RateLimiter, since the
+stock engine matches MaxRate but doesn't enforce it); tier 2 semantic
+validation of write content (page contract, T-box, vault-graph SKOS checks
+via VaultReader — cycle-introducing write denied). DENY reasons embed JSON
+diagnostics after a "diagnostics: " marker; ParseDiagnostics round-trips
+them for agent self-correction. 9 new tests, module green.
+
 ## [2026-07-30] 1.3 thesaurus fixture gate | DONE
 Fixture tests: full_skos + transitive_broader pass, cycle_detection +
 inconsistency_broader_narrower rejected with diagnostics, symmetric_related

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,12 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 0.2 skeleton + vault + schema | DONE
+Added `ontologies/` submodule, `go/memory/` package (doc.go + Vault with
+per-user layout, kebab-case page ids, and path-boundary containment —
+defense-in-depth half of user isolation), root `SCHEMA.md` (frontmatter
+contract, prefixes, typed-link syntax, ingest workflow) and
+`SCHEMA_GAPS.md`. `go test ./...` and `go vet ./...` green.
+
 ## [2026-07-30] 0.1 placement + RDF spike | DONE
 Spiked `deiu/rdf2go` vs `knakk/rdf` against the real T-box
 (`TBOX_LEARNING_SOFTWARE.ttl`, 671 triples) and three thesaurus fixtures —

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,16 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 3.1 Python SDK WikiMemory + LangGraph tools | DONE
+`pedro_agentware.memory`: WikiMemory spawns `memctl serve` per user (MCP
+stdio, per SDK plan subprocess mode), implements the SDK's ToolExecutor
+protocol so it composes into MiddlewareImpl; native API (ingest,
+write_page, query, get_claims, lint), parse_diagnostics for the DENY
+payload; LangGraphMemoryTools exposes the five tools as plain callables
+(denies render as "DENIED: ..." with diagnostics so agents self-correct).
+Tests build the real Go binary and exercise round-trip, deny diagnostics,
+cross-user isolation. Go executor now emits [] not null for empty results.
+ruff + mypy --strict clean.
+
 ## [2026-07-30] 2.x MCP stdio server + memctl serve | DONE
 `go/mcp`: minimal MCP server (JSON-RPC 2.0 newline-delimited over any
 reader/writer; initialize, ping, tools/list, tools/call) serving a

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,16 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 4.1+4.2 TypeScript SDK + cross-SDK isolation | DONE
+`typescript/src/memory`: async WikiMemory MCP stdio client (spawns memctl
+serve per user; pending-FIFO correlation; same surface as Python minus
+inference), parseDiagnostics, and memoryTools() in the Vercel AI SDK tool
+shape (zod parameters; denies render as "DENIED: ..." for
+self-correction). Jest: 5 new tests incl. cross-SDK — a page written via
+the Python SDK is queryable via the TS SDK for the same user and invisible
+(empty query + claims) for another user. tsc build green, 131 TS tests
+pass. Note: `npm run lint` is broken pre-existing (direct minimatch@10.2.3
+pin shadows eslint 8's CJS minimatch) — untouched by this work.
+
 ## [2026-07-30] 3.3 dogfood: enforced ingest → contradiction → inference | DONE
 Schema gains claim-to-claim refs (claims[].supports/contradicts, "c2" or
 "page#c2") — parsed in Go, surfaced by memory_get_claims, documented in

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,19 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 3.3 dogfood: enforced ingest → contradiction → inference | DONE
+Schema gains claim-to-claim refs (claims[].supports/contradicts, "c2" or
+"page#c2") — parsed in Go, surfaced by memory_get_claims, documented in
+SCHEMA.md. Python glue pedro_agentware.memory.confidence builds the
+inference request from vault claims and merges marginals back.
+examples/wiki_memory_dogfood.py drives the LangGraph tool surface against
+the real Go core: 3 overlapping sources ingested; first page write DENIED
+(twitch:Golang, unknown-concept) and self-corrected to twitch:Go from the
+nearest-term diagnostics (deny→retry logged); 4th contradicting source
+recorded; inference run and confidence written back through the enforced
+path. Results: c1 0.962→0.941 (drops), contrarian c3 0.211 with
+contested=true, all via belief propagation. Suite: 119 python + all Go
+green; ruff + mypy strict clean.
+
 ## [2026-07-30] 3.2 pgmpy inference engine + JSON contract | DONE
 Contract at go/memory/infer/schema.json (one schema for subprocess and
 future MCP transports). Engine at pedro_agentware.memory.infer (pgmpy

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,0 +1,9 @@
+# Wiki Memory — Build Log
+
+## [2026-07-30] 0.1 placement + RDF spike | DONE
+Spiked `deiu/rdf2go` vs `knakk/rdf` against the real T-box
+(`TBOX_LEARNING_SOFTWARE.ttl`, 671 triples) and three thesaurus fixtures —
+both parsed all files identically. Chose `knakk/rdf` (zero deps,
+deterministic streaming decode, typed terms). Placement: in-monorepo
+(`go/memory/` + SDK mirrors). Recorded D1–D4 in `DECISIONS.md`; created
+`PROGRESS.md` and this log.

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,15 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 5.1 competency-question queries | DONE
+memory_query gains structured kinds (go/memory/query.go): prerequisites
+and builds_toward (cycle-safe BFS closures with depth), learning_path
+(skills appropriate for a role plus their transitive prerequisites,
+topologically ordered), contested_claims, low_confidence (threshold arg,
+default 0.6). Keyword search stays as the free-text fallback. Five new
+chain tests over a realistic skill graph written through the enforced
+path; full Go suite + vet green. (Committed in the prior commit; log
+updated here.)
+
 ## [2026-07-30] 4.1+4.2 TypeScript SDK + cross-SDK isolation | DONE
 `typescript/src/memory`: async WikiMemory MCP stdio client (spawns memctl
 serve per user; pending-FIFO correlation; same surface as Python minus

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,12 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 5.4 REPORT.md | DONE — STOP CONDITION MET
+All phases checked, suites green (Go: all packages; Python: 119 + 1
+dogfood; TS: 131). REPORT.md written: component summary, fixture
+pass table (5/5), known gaps (ontology-go#18 pin, stdio-only MCP,
+caller-orchestrated inference, hand-set weights), three v2
+recommendations. Loop complete.
+
 ## [2026-07-30] 5.3 E2E CI workflow | DONE
 .github/workflows/memory-e2e.yml: fresh clone with submodules → Go 1.26
 core tests → memctl build + vault lint → uv python 3.12 with

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,14 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 1.3 thesaurus fixture gate | DONE
+Fixture tests: full_skos + transitive_broader pass, cycle_detection +
+inconsistency_broader_narrower rejected with diagnostics, symmetric_related
+symmetry inferred (idempotent), cycle-safe TransitiveBroader closure added.
+The gate exposed an upstream bug: ontology-go's inconsistent-hierarchy
+check tested the inverse direction (false positives on full_skos, false
+negative on the inconsistency fixture). Fixed upstream per loop rules —
+ontology-go PR #18 — and pinned go.mod to the fix commit (BLOCKERS.md).
+
 ## [2026-07-30] 1.2 T-box validation rules + memctl lint | DONE
 `go/memory/ontology`: TBox loader (classes, properties w/ domain+range,
 SKOS concepts, label index) over ontology-go's ttl parser; ValidatePage

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,16 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 2.x MCP stdio server + memctl serve | DONE
+`go/mcp`: minimal MCP server (JSON-RPC 2.0 newline-delimited over any
+reader/writer; initialize, ping, tools/list, tools/call) serving a
+tools.ToolRegistry with a fixed CallerContext — one process per principal,
+matching the SDK plan's subprocess mode; scope can't be overridden in-band.
+`memctl serve -root -tbox -user` wires WikiMemory behind it. Policy denies
+surface as MCP tool errors with the diagnostics payload intact. Tests cover
+list/call round-trip, deny-with-diagnostics, unknown method/tool; smoke:
+piped JSON-RPC ingest landed in the vault. Closes the missing-MCP watch
+item for the stdio transport (HTTP+SSE still future).
+
 ## [2026-07-30] 2.2+2.3 executor, chain wiring, isolation tests | DONE
 `go/memory`: Executor (five tools over the per-user vault, every path
 re-checked against the vault boundary, index/log maintenance, v1 keyword

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,16 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 1.2 T-box validation rules + memctl lint | DONE
+`go/memory/ontology`: TBox loader (classes, properties w/ domain+range,
+SKOS concepts, label index) over ontology-go's ttl parser; ValidatePage
+(class/property/concept existence, domain/range with transitive subclass,
+unknown-prefix) returning structured Violations with nearest-term
+suggestions (Levenshtein); CheckSKOSGraph wrapping ontology-go validate
+(cycles, broader/narrower inconsistency); InferSymmetricRelated.
+CI consumer: `go/cmd/memctl` `lint` subcommand (maintainer approved CLI
+tooling for this). Smoke test: bad page → 2 violations w/ suggestions,
+exit 1. Tests green against real T-box submodule.
+
 ## [2026-07-30] 1.1 page parser → A-box | DONE
 `go/memory/page`: YAML frontmatter parser (strict fields, kebab-case ids,
 CURIE types/preds, unique claim ids), typed-wikilink extraction

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,22 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 5.3 E2E CI workflow | DONE
+.github/workflows/memory-e2e.yml: fresh clone with submodules → Go 1.26
+core tests → memctl build + vault lint → uv python 3.12 with
+[dev,inference] extras → full pytest (client, inference, dogfood) →
+dogfood example as the explicit enable→ingest→deny/retry→infer→query
+chain (example now finishes with contested_claims and low_confidence
+queries; dogfood test asserts both return exactly c3) → Node LTS
+TypeScript suite incl. the cross-SDK isolation test. All steps verified
+locally before push.
+
+## [2026-07-30] 5.2 memory_lint hygiene checks | DONE
+Lint now layers hygiene findings over the ontology/SKOS checks:
+orphan-page (no links in or out), dangling-link (mentioned but pageless),
+stale-page (frontmatter `updated` older than stale_days, default 90),
+missing-typed-links (only bare skos:related). Chain test covers all four
+plus healthy-page silence and the tunable threshold.
+
 ## [2026-07-30] 5.1 competency-question queries | DONE
 memory_query gains structured kinds (go/memory/query.go): prerequisites
 and builds_toward (cycle-safe BFS closures with depth), learning_path

--- a/BUILD_LOG.md
+++ b/BUILD_LOG.md
@@ -1,5 +1,20 @@
 # Wiki Memory — Build Log
 
+## [2026-07-30] 2.2+2.3 executor, chain wiring, isolation tests | DONE
+`go/memory`: Executor (five tools over the per-user vault, every path
+re-checked against the vault boundary, index/log maintenance, v1 keyword
+query, claims listing, vault lint incl. dangling links) implementing both
+ToolExecutor and VaultReader; WikiMemory Enable(Config) wiring
+NewMiddleware(exec).WithPolicy(OntologyEvaluator).WithAuditor(...);
+RegisterTools for the tool registry. Added exported
+middleware.CallerFromContext (in-repo API gap — executors couldn't read
+the caller). Chain tests: valid write persists + index/log update; deny
+carries diagnostics AND lands in auditor; cycle via real vault denied;
+anonymous denied; cross-user isolation (policy deny on scope-override arg,
+scoped query/claims, path rejection). Note: the repo has no MCP server
+package yet — tools are registry-registered; MCP exposure rides the SDK
+transport work.
+
 ## [2026-07-30] 2.1 OntologyEvaluator + declarative policy | DONE
 `go/memory`: two-tier evaluator implementing middleware.PolicyEvaluator —
 tier 1 embedded policy.yaml (deny-by-default, scope-override + anonymous

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -49,6 +49,28 @@ without error and agreed on triple counts.
 **Consequence:** `go/memory/` builds a small internal graph index on top of
 knakk's triple stream; the T-box loader is read-only.
 
+## D5: RDF library — `github.com/soypete/ontology-go` (supersedes D2)
+
+**Decision:** per maintainer direction, use the maintainer's own RDF toolkit
+`github.com/soypete/ontology-go` instead of `knakk/rdf`.
+
+**Why it's a strictly better fit:**
+- `ttl` package: full Turtle parser → `[]types.Triple` (plain-string terms
+  with `IsLiteral`/`Language`/`Datatype` flags) — parses the T-box directly.
+- `validate` package: qSKOS-style validator that already detects
+  `circular_broader_relation` and `inconsistent_hierarchy` — precisely the
+  thesaurus fixture requirements for Phase 1.
+- `reasoner` package: TransitiveBroader/Narrower, SymmetricRelated, and
+  Inconsistency rules — covers the `transitive_broader.ttl` and
+  `symmetric_related.ttl` fixture behavior.
+- `sparql`/`store`: query layer usable by `memory_query` in Phase 5.
+- Same owner as this repo and the ontologies — gaps can be fixed upstream
+  (loop rule: upstream issues/PRs, never forks).
+
+**Consequence:** `knakk/rdf` removed. ontology-go has no tagged releases yet,
+so we pin a pseudo-version of `main`. N-Triples serialization is a small
+local formatter in `go/memory/page` (ontology-go has none).
+
 ## D3: Ontology distribution — git submodule at `ontologies/`
 
 **Decision:** vendor `github.com/Soypete/ontologies` as a git submodule at the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,67 @@
+# Wiki Memory — Decisions
+
+Decision log for the ontology-constrained wiki memory component. One entry per
+decision; newest at the bottom.
+
+## D1: Placement — in-monorepo (`go/memory/`)
+
+**Decision:** Wiki memory lives in this monorepo as `go/memory/` (Go core),
+`python/src/pedro_agentware/memory/` (Python SDK), and
+`typescript/src/memory/` (TypeScript SDK). No companion repo.
+
+**Why:**
+- The SDK plan (`business/SDK_PLAN.md`) makes the Go module the engine and the
+  Python/TS packages clients. Memory enforcement composes directly with
+  `middleware.NewMiddleware(exec).WithPolicy(...).WithAuditor(...)` and
+  implements the existing `middleware.PolicyEvaluator` interface — a companion
+  repo would need version-locked imports of those interfaces and would churn on
+  every middleware change.
+- Composable components in this repo already live together (guardrails,
+  toolformat, adapters); memory is another composable option, not a product.
+- CI is already path-filtered per language (`.github/workflows/*-test.yml`),
+  so memory changes ride the existing pipelines.
+
+**Trade-off accepted:** the monorepo grows; mitigated by memory being a
+self-contained package with no imports from it into the existing core.
+
+## D2: Go RDF library — `knakk/rdf`
+
+**Spike:** parsed `education/TBOX_LEARNING_SOFTWARE.ttl` (671 triples),
+`thesaurus/full_skos.ttl` (75), `thesaurus/cycle_detection.ttl` (9), and
+`social/twitch_topics.ttl` (121) with both candidates. Both parsed everything
+without error and agreed on triple counts.
+
+**Decision:** `github.com/knakk/rdf`.
+
+**Why:**
+- **Zero transitive dependencies** — pure stdlib. `deiu/rdf2go` pulls in
+  `linkeddata/gojsonld` and `rychipman/easylex` (both unmaintained since 2017).
+  Loop rule: "Go stdlib + one RDF lib" — knakk is exactly that.
+- **Deterministic, streaming decode** — `NewTripleDecoder(r, rdf.Turtle)`
+  yields triples in document order. rdf2go stores triples in a map and
+  iterates in nondeterministic order, which makes golden tests flaky.
+- **Typed terms** — `rdf.IRI` / `rdf.Literal` / `rdf.Blank` are distinguishable
+  via `Term.Type()`; rdf2go stringifies terms, which loses the IRI/literal
+  distinction we need for domain/range checks.
+- We need our own indexed graph (subject → predicate → objects) for T-box
+  lookups anyway, so rdf2go's built-in graph container adds nothing.
+
+**Consequence:** `go/memory/` builds a small internal graph index on top of
+knakk's triple stream; the T-box loader is read-only.
+
+## D3: Ontology distribution — git submodule at `ontologies/`
+
+**Decision:** vendor `github.com/Soypete/ontologies` as a git submodule at the
+repo root (`ontologies/`). The T-box path is a *parameter* of `WikiMemory`
+(default points at the submodule), so users can supply their own T-box without
+forking. The T-box is read-only; gaps go to `SCHEMA_GAPS.md`, never invented
+terms.
+
+## D4: Inference transport — subprocess with JSON contract first
+
+**Decision:** the Go core invokes the Python inference engine (pgmpy) as a
+subprocess speaking the JSON contract in `go/memory/infer/schema.json`
+(nodes + typed edges + weights in; per-claim marginals + `contested` flags
+out). The same contract is reusable over an MCP tool call later; subprocess
+first because it needs zero deployment topology and matches the SDK plan's
+"spawn as subprocess — zero config" mode.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -25,8 +25,8 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 - [x] Dogfood: LangGraph agent ingests 3 overlapping sources + 1 contradicting source; confidence drops, flag sets, deny→retry logged
 
 ## Phase 4 — TypeScript SDK
-- [ ] Enablement surface + MCP client parity with Python (minus inference); one TS framework integration example
-- [ ] Cross-SDK test: page written via Python SDK readable via TS SDK for same user, invisible for different user
+- [x] Enablement surface + MCP client parity with Python (minus inference); one TS framework integration example (Vercel AI SDK tool shape)
+- [x] Cross-SDK test: page written via Python SDK readable via TS SDK for same user, invisible for different user
 
 ## Phase 5 — Query, lint, report
 - [ ] `memory_query` answers L2WS competency questions + contested claims + low-confidence claims

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,8 +15,8 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 
 ## Phase 2 — Middleware integration (Go core)
 - [x] `OntologyEvaluator` implementing `PolicyEvaluator`; declarative policy YAML (deny-by-default, user-scope rule, rate limits)
-- [ ] Memory executor wired via `NewMiddleware(exec).WithAuditor(...)`; MCP tools registered (memory_ingest, memory_write_page, memory_query, memory_get_claims, memory_lint)
-- [ ] Tests: valid write → ALLOW; unknown class → DENY + nearest-term diagnostic; cycle-introducing link → DENY; denies audited; user A cannot touch user B's vault (policy AND path check)
+- [x] Memory executor wired via `NewMiddleware(exec).WithAuditor(...)`; tools registered (memory_ingest, memory_write_page, memory_query, memory_get_claims, memory_lint) — MCP server exposure pending (Phase 4 MCP client work; noted in BLOCKERS.md watch list)
+- [x] Tests: valid write → ALLOW; unknown class → DENY + nearest-term diagnostic; cycle-introducing link → DENY; denies audited; user A cannot touch user B's vault (policy AND path check)
 - [ ] agentware API gaps → upstream issue/PR, noted in `BLOCKERS.md`
 
 ## Phase 3 — Python SDK + inference

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,7 +10,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 
 ## Phase 1 — Validation core (shared package)
 - [x] Frontmatter + typed-wikilink parser → N-Triples (A-box)
-- [ ] T-box validation rules (class/predicate existence, domain/range, SKOS acyclicity + broader/narrower consistency) as ONE package with two consumers (OntologyEvaluator + CI check)
+- [x] T-box validation rules (class/predicate existence, domain/range, SKOS acyclicity + broader/narrower consistency) as ONE package with two consumers (OntologyEvaluator + CI check via `memctl lint`)
 - [ ] Fixture tests per the thesaurus files (pass full_skos + transitive_broader; reject cycle_detection + inconsistency_broader_narrower with diagnostics; infer symmetry from symmetric_related)
 
 ## Phase 2 — Middleware integration (Go core)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,7 +6,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 
 ## Phase 0 — Scaffold + decisions
 - [x] Placement decision (in-monorepo) + Go RDF lib spike (knakk/rdf) → `DECISIONS.md`
-- [ ] `memory/` package skeleton, per-user vault layout, `SCHEMA.md`, `SCHEMA_GAPS.md`, ontologies submodule
+- [x] `memory/` package skeleton, per-user vault layout, `SCHEMA.md`, `SCHEMA_GAPS.md`, ontologies submodule
 
 ## Phase 1 — Validation core (shared package)
 - [ ] Frontmatter + typed-wikilink parser → N-Triples (A-box)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -29,7 +29,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 - [x] Cross-SDK test: page written via Python SDK readable via TS SDK for same user, invisible for different user
 
 ## Phase 5 — Query, lint, report
-- [ ] `memory_query` answers L2WS competency questions + contested claims + low-confidence claims
+- [x] `memory_query` answers L2WS competency questions + contested claims + low-confidence claims
 - [ ] `memory_lint`: orphan pages, pageless concepts, stale pages, missing typed links
 - [ ] E2E in CI: fresh clone → enable memory → ingest → infer → query, green
 - [ ] `REPORT.md`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -30,6 +30,6 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 
 ## Phase 5 — Query, lint, report
 - [x] `memory_query` answers L2WS competency questions + contested claims + low-confidence claims
-- [ ] `memory_lint`: orphan pages, pageless concepts, stale pages, missing typed links
-- [ ] E2E in CI: fresh clone → enable memory → ingest → infer → query, green
+- [x] `memory_lint`: orphan pages, pageless concepts, stale pages, missing typed links
+- [x] E2E in CI: fresh clone → enable memory → ingest → infer → query, green (.github/workflows/memory-e2e.yml)
 - [ ] `REPORT.md`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,7 +9,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 - [x] `memory/` package skeleton, per-user vault layout, `SCHEMA.md`, `SCHEMA_GAPS.md`, ontologies submodule
 
 ## Phase 1 — Validation core (shared package)
-- [ ] Frontmatter + typed-wikilink parser → N-Triples (A-box)
+- [x] Frontmatter + typed-wikilink parser → N-Triples (A-box)
 - [ ] T-box validation rules (class/predicate existence, domain/range, SKOS acyclicity + broader/narrower consistency) as ONE package with two consumers (OntologyEvaluator + CI check)
 - [ ] Fixture tests per the thesaurus files (pass full_skos + transitive_broader; reject cycle_detection + inconsistency_broader_narrower with diagnostics; infer symmetry from symmetric_related)
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -21,7 +21,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 
 ## Phase 3 — Python SDK + inference
 - [x] `WikiMemory` enablement in Python SDK (composable option, user scope from CallerContext), LangGraph integration exposing memory tools
-- [ ] pgmpy inference engine + JSON contract; unit tests (mutual support > 0.85; contradicted+superseded < 0.5 and contested; convergence or Gibbs fallback on cycle)
+- [x] pgmpy inference engine + JSON contract; unit tests (mutual support > 0.85; contradicted+superseded < 0.5 and contested; convergence or Gibbs fallback on cycle)
 - [ ] Dogfood: LangGraph agent ingests 3 overlapping sources + 1 contradicting source; confidence drops, flag sets, deny→retry logged
 
 ## Phase 4 — TypeScript SDK

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -22,7 +22,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 ## Phase 3 — Python SDK + inference
 - [x] `WikiMemory` enablement in Python SDK (composable option, user scope from CallerContext), LangGraph integration exposing memory tools
 - [x] pgmpy inference engine + JSON contract; unit tests (mutual support > 0.85; contradicted+superseded < 0.5 and contested; convergence or Gibbs fallback on cycle)
-- [ ] Dogfood: LangGraph agent ingests 3 overlapping sources + 1 contradicting source; confidence drops, flag sets, deny→retry logged
+- [x] Dogfood: LangGraph agent ingests 3 overlapping sources + 1 contradicting source; confidence drops, flag sets, deny→retry logged
 
 ## Phase 4 — TypeScript SDK
 - [ ] Enablement surface + MCP client parity with Python (minus inference); one TS framework integration example

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -20,7 +20,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 - [x] agentware API gaps → upstream issue/PR, noted in `BLOCKERS.md` (middleware.CallerFromContext added in-repo; ontology-go#18 upstream; missing mcp package tracked)
 
 ## Phase 3 — Python SDK + inference
-- [ ] `WikiMemory` enablement in Python SDK (composable option, user scope from CallerContext), LangGraph integration exposing memory tools
+- [x] `WikiMemory` enablement in Python SDK (composable option, user scope from CallerContext), LangGraph integration exposing memory tools
 - [ ] pgmpy inference engine + JSON contract; unit tests (mutual support > 0.85; contradicted+superseded < 0.5 and contested; convergence or Gibbs fallback on cycle)
 - [ ] Dogfood: LangGraph agent ingests 3 overlapping sources + 1 contradicting source; confidence drops, flag sets, deny→retry logged
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,7 +14,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 - [x] Fixture tests per the thesaurus files (pass full_skos + transitive_broader; reject cycle_detection + inconsistency_broader_narrower with diagnostics; infer symmetry from symmetric_related)
 
 ## Phase 2 — Middleware integration (Go core)
-- [ ] `OntologyEvaluator` implementing `PolicyEvaluator`; declarative policy YAML (deny-by-default, user-scope rule, rate limits)
+- [x] `OntologyEvaluator` implementing `PolicyEvaluator`; declarative policy YAML (deny-by-default, user-scope rule, rate limits)
 - [ ] Memory executor wired via `NewMiddleware(exec).WithAuditor(...)`; MCP tools registered (memory_ingest, memory_write_page, memory_query, memory_get_claims, memory_lint)
 - [ ] Tests: valid write → ALLOW; unknown class → DENY + nearest-term diagnostic; cycle-introducing link → DENY; denies audited; user A cannot touch user B's vault (policy AND path check)
 - [ ] agentware API gaps → upstream issue/PR, noted in `BLOCKERS.md`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,35 @@
+# Wiki Memory — Progress
+
+State file for the wiki-memory build loop. One checkbox per iteration.
+Phases from the loop prompt; see `DECISIONS.md` for decisions,
+`BUILD_LOG.md` for the iteration log, `BLOCKERS.md` for blockers.
+
+## Phase 0 — Scaffold + decisions
+- [x] Placement decision (in-monorepo) + Go RDF lib spike (knakk/rdf) → `DECISIONS.md`
+- [ ] `memory/` package skeleton, per-user vault layout, `SCHEMA.md`, `SCHEMA_GAPS.md`, ontologies submodule
+
+## Phase 1 — Validation core (shared package)
+- [ ] Frontmatter + typed-wikilink parser → N-Triples (A-box)
+- [ ] T-box validation rules (class/predicate existence, domain/range, SKOS acyclicity + broader/narrower consistency) as ONE package with two consumers (OntologyEvaluator + CI check)
+- [ ] Fixture tests per the thesaurus files (pass full_skos + transitive_broader; reject cycle_detection + inconsistency_broader_narrower with diagnostics; infer symmetry from symmetric_related)
+
+## Phase 2 — Middleware integration (Go core)
+- [ ] `OntologyEvaluator` implementing `PolicyEvaluator`; declarative policy YAML (deny-by-default, user-scope rule, rate limits)
+- [ ] Memory executor wired via `NewMiddleware(exec).WithAuditor(...)`; MCP tools registered (memory_ingest, memory_write_page, memory_query, memory_get_claims, memory_lint)
+- [ ] Tests: valid write → ALLOW; unknown class → DENY + nearest-term diagnostic; cycle-introducing link → DENY; denies audited; user A cannot touch user B's vault (policy AND path check)
+- [ ] agentware API gaps → upstream issue/PR, noted in `BLOCKERS.md`
+
+## Phase 3 — Python SDK + inference
+- [ ] `WikiMemory` enablement in Python SDK (composable option, user scope from CallerContext), LangGraph integration exposing memory tools
+- [ ] pgmpy inference engine + JSON contract; unit tests (mutual support > 0.85; contradicted+superseded < 0.5 and contested; convergence or Gibbs fallback on cycle)
+- [ ] Dogfood: LangGraph agent ingests 3 overlapping sources + 1 contradicting source; confidence drops, flag sets, deny→retry logged
+
+## Phase 4 — TypeScript SDK
+- [ ] Enablement surface + MCP client parity with Python (minus inference); one TS framework integration example
+- [ ] Cross-SDK test: page written via Python SDK readable via TS SDK for same user, invisible for different user
+
+## Phase 5 — Query, lint, report
+- [ ] `memory_query` answers L2WS competency questions + contested claims + low-confidence claims
+- [ ] `memory_lint`: orphan pages, pageless concepts, stale pages, missing typed links
+- [ ] E2E in CI: fresh clone → enable memory → ingest → infer → query, green
+- [ ] `REPORT.md`

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -17,7 +17,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 - [x] `OntologyEvaluator` implementing `PolicyEvaluator`; declarative policy YAML (deny-by-default, user-scope rule, rate limits)
 - [x] Memory executor wired via `NewMiddleware(exec).WithAuditor(...)`; tools registered (memory_ingest, memory_write_page, memory_query, memory_get_claims, memory_lint) — MCP server exposure pending (Phase 4 MCP client work; noted in BLOCKERS.md watch list)
 - [x] Tests: valid write → ALLOW; unknown class → DENY + nearest-term diagnostic; cycle-introducing link → DENY; denies audited; user A cannot touch user B's vault (policy AND path check)
-- [ ] agentware API gaps → upstream issue/PR, noted in `BLOCKERS.md`
+- [x] agentware API gaps → upstream issue/PR, noted in `BLOCKERS.md` (middleware.CallerFromContext added in-repo; ontology-go#18 upstream; missing mcp package tracked)
 
 ## Phase 3 — Python SDK + inference
 - [ ] `WikiMemory` enablement in Python SDK (composable option, user scope from CallerContext), LangGraph integration exposing memory tools

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -32,4 +32,6 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 - [x] `memory_query` answers L2WS competency questions + contested claims + low-confidence claims
 - [x] `memory_lint`: orphan pages, pageless concepts, stale pages, missing typed links
 - [x] E2E in CI: fresh clone → enable memory → ingest → infer → query, green (.github/workflows/memory-e2e.yml)
-- [ ] `REPORT.md`
+- [x] `REPORT.md`
+
+**All phases complete (2026-07-30).** See REPORT.md.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,7 +11,7 @@ Phases from the loop prompt; see `DECISIONS.md` for decisions,
 ## Phase 1 — Validation core (shared package)
 - [x] Frontmatter + typed-wikilink parser → N-Triples (A-box)
 - [x] T-box validation rules (class/predicate existence, domain/range, SKOS acyclicity + broader/narrower consistency) as ONE package with two consumers (OntologyEvaluator + CI check via `memctl lint`)
-- [ ] Fixture tests per the thesaurus files (pass full_skos + transitive_broader; reject cycle_detection + inconsistency_broader_narrower with diagnostics; infer symmetry from symmetric_related)
+- [x] Fixture tests per the thesaurus files (pass full_skos + transitive_broader; reject cycle_detection + inconsistency_broader_narrower with diagnostics; infer symmetry from symmetric_related)
 
 ## Phase 2 — Middleware integration (Go core)
 - [ ] `OntologyEvaluator` implementing `PolicyEvaluator`; declarative policy YAML (deny-by-default, user-scope rule, rate limits)

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,131 @@
+# Wiki Memory — Build Report
+
+Ontology-constrained wiki memory for pedro-agentware: an LLM-maintained,
+per-user markdown wiki with T-box enforcement on every write and a Markov
+link network for claim confidence. Built 2026-07-30 across 15 loop
+iterations; every phase of the plan is complete.
+
+## What was built
+
+**Go core (`go/memory`, `go/mcp`, `go/cmd/memctl`)** — the engine:
+
+- `memory.Vault` — per-user vault layout (`<root>/<user>/wiki/` + `raw/`)
+  with kebab-case ids and path-boundary containment.
+- `memory/page` — frontmatter + typed-wikilink parser
+  (`[[t|pred=sw:buildsToward]]`, bare `[[t]]` → skos:related), claim
+  supports/contradicts refs, A-box emission as N-Triples.
+- `memory/ontology` — ONE validation package with two consumers
+  (evaluator + `memctl lint`): T-box loading via
+  `github.com/soypete/ontology-go`, class/property/concept existence,
+  domain/range over transitive subclass, SKOS cycle and
+  broader/narrower-consistency checks, nearest-term suggestions
+  (Levenshtein), SKOS label→concept matching for ingest.
+- `memory.OntologyEvaluator` — implements the stock
+  `middleware.PolicyEvaluator`. Tier 1: embedded declarative
+  `policy.yaml` (deny-by-default, scope-override and anonymous denies,
+  per-user+tool rate limits). Tier 2: semantic validation of page writes,
+  including graph checks against the caller's existing vault
+  (cycle-introducing writes denied). DENY reasons embed a JSON
+  diagnostics payload agents parse to self-correct.
+- `memory.Enable(Config)` — the composable enablement:
+  `NewMiddleware(exec).WithPolicy(evaluator).WithAuditor(auditor)`; five
+  tools (`memory_ingest`, `memory_write_page`, `memory_query`,
+  `memory_get_claims`, `memory_lint`) registered on the tool registry.
+  Every decision audited; user scope comes only from `CallerContext`
+  (policy AND path check — defense in depth, tested both ways).
+- `go/mcp` + `memctl serve` — minimal MCP stdio server (JSON-RPC 2.0)
+  exposing any tool registry with a fixed per-process principal; the SDK
+  transport per `business/SDK_PLAN.md`. `memctl lint` is the CI/dev
+  consumer of the validation rules.
+- `memory_query` competency questions: transitive prerequisites,
+  builds-toward, learning path to a role (topologically ordered),
+  contested claims, low-confidence claims. `memory_lint`: ontology +
+  graph checks plus orphan pages, dangling (pageless) targets, stale
+  pages, missing typed links.
+
+**Python SDK (`pedro_agentware.memory`)** — client + inference:
+
+- `WikiMemory` spawns `memctl serve` per user over MCP stdio; implements
+  the SDK's `ToolExecutor` protocol so it composes into `MiddlewareImpl`;
+  `parse_diagnostics` for deny payloads; `LangGraphMemoryTools` exposes
+  the tools to LangGraph agents (denies render as `DENIED: ...`).
+- `memory.infer` (pgmpy, `inference` extra, uv/py3.12) — the Markov link
+  network per `go/memory/infer/schema.json`: binary claim/source nodes,
+  supports 0.8 / contradicts 0.9 / sourceOf 0.85 potentials, source
+  priors 0.7 (0.4 superseded), belief propagation with Gibbs fallback,
+  `contested` flags. Runnable as a subprocess (`python -m`).
+- `memory.confidence` — builds inference requests from vault claims and
+  merges marginals back for write-back through the enforced path.
+- Dogfood (`examples/wiki_memory_dogfood.py`, tested): 3 overlapping
+  sources ingested; a write denied for `twitch:Golang` self-corrects to
+  `twitch:Go` from the diagnostics; a 4th contradicting source drops the
+  claim 0.962→0.941 and flags the contrarian claim contested at 0.211;
+  confidence written back; queries reflect the inferred state.
+
+**TypeScript SDK (`typescript/src/memory`)** — async `WikiMemory` MCP
+client (parity minus inference), `parseDiagnostics`, and `memoryTools()`
+in the Vercel AI SDK tool shape (zod parameters). Cross-SDK test: a page
+written via the Python SDK is queryable via the TS SDK for the same user
+and invisible to another user.
+
+**CI** — `.github/workflows/memory-e2e.yml`: fresh clone with submodules
+→ Go tests → memctl lint → Python suite with inference → dogfood chain →
+TS suite. All steps verified locally.
+
+## Fixture gate (thesaurus)
+
+| Fixture | Required behavior | Result |
+|---|---|---|
+| `full_skos.ttl` | pass clean | PASS (after upstream fix, see gaps) |
+| `transitive_broader.ttl` | pass; selfPaced closes to course | PASS |
+| `cycle_detection.ttl` | reject with diagnostics; traversal terminates | PASS (skos-cycle, subjects named) |
+| `inconsistency_broader_narrower.ttl` | reject with diagnostics | PASS (skos-inconsistent-hierarchy) |
+| `symmetric_related.ttl` | infer symmetry, idempotent | PASS |
+
+Inference spec tests: mutual support from reliable sources → 0.877 both
+(> 0.85); contradicted claim from superseded source → 0.223 (< 0.5) and
+contested; support cycle → exact via belief propagation.
+
+## Known gaps
+
+- **ontology-go PR #18 pending** — the fixture gate exposed an inverted
+  direction check in upstream's inconsistent-hierarchy validation (false
+  positives on valid inverse pairs, false negative on the real
+  contradiction). Fixed upstream with regression tests
+  (https://github.com/Soypete/ontology-go/pull/18); `go.mod` pins the
+  canonical module at the fix commit until merge (no fork).
+- **MCP transport is stdio-only** — one `memctl serve` process per
+  principal. The SDK plan's HTTP+SSE sidecar mode (multi-user, caller
+  identity per request) is not built.
+- **Supersedes has no on-disk syntax** — the inference contract and
+  engine support `supersedes`, but raw sources carry no metadata file, so
+  supersession is passed explicitly to `build_inference_request`.
+- **Hand-set weights** — potentials are config, not learned; no MLN
+  grounder in v1 (as planned). Weight learning is future work.
+- **Inference is caller-orchestrated** — the Go core does not yet invoke
+  the Python engine itself; the SDK (or agent) runs infer and writes back
+  through the enforced path. The JSON contract is transport-ready.
+- Pre-existing repo issues, untouched: `npm run lint` broken by a direct
+  `minimatch@10` pin shadowing eslint's; `tests/adapters` style
+  violations (CI lints `src/` only); `SCHEMA_GAPS.md` is empty — the
+  L2WS T-box covered everything the dogfood needed.
+
+## Three recommendations for v2
+
+1. **HTTP+SSE MCP sidecar with per-request principals.** The per-user
+   subprocess model is right for dev and single-agent use, but a shared
+   deployment needs one server that derives `CallerContext` from
+   authenticated request metadata — then the same policy tier serves
+   many users, and the inference engine can be invoked server-side after
+   each write instead of by the client.
+2. **Close the ingest→page loop with SKOS label matching.** The T-box
+   label index (`MatchConceptLabel`, "Golang" → `twitch:Go`) is built
+   but memory_ingest doesn't use it yet: v2 should propose topic tags
+   and typed-link candidates at ingest time, turning deny→retry cycles
+   into pre-corrected first writes, and add source metadata (reliability,
+   supersedes) as a small frontmatter block on `raw/` files.
+3. **Learn edge weights from vault history.** Every decision is audited
+   and confidence is versioned in git-friendly markdown; that history is
+   training data. Start with per-source reliability estimated from how
+   often a source's claims end up contested or reverted, before
+   attempting full MLN weight learning.

--- a/REPORT.md
+++ b/REPORT.md
@@ -88,12 +88,12 @@ contested; support cycle → exact via belief propagation.
 
 ## Known gaps
 
-- **ontology-go PR #18 pending** — the fixture gate exposed an inverted
+- **ontology-go PR #18 — merged.** The fixture gate exposed an inverted
   direction check in upstream's inconsistent-hierarchy validation (false
   positives on valid inverse pairs, false negative on the real
   contradiction). Fixed upstream with regression tests
-  (https://github.com/Soypete/ontology-go/pull/18); `go.mod` pins the
-  canonical module at the fix commit until merge (no fork).
+  (https://github.com/Soypete/ontology-go/pull/18, merged 2026-07-30);
+  `go.mod` tracks upstream main again.
 - **MCP transport is stdio-only** — one `memctl serve` process per
   principal. The SDK plan's HTTP+SSE sidecar mode (multi-user, caller
   identity per request) is not built.

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -54,6 +54,10 @@ Rules:
 - `claims[].id` — unique within the page; referenced by the inference
   engine. `confidence` is owned by inference (leave `null` on write);
   `contested: true` is set when a confident opposing claim exists.
+- `claims[].supports` / `claims[].contradicts` — optional lists of claim
+  references: `c2` for a claim in the same page, `other-page#c1` across
+  pages. These become the `supports`/`contradicts` edges of the Markov
+  link network.
 - `sources` — ids of entries under `raw/`.
 - `updated` — ISO date of last substantive edit.
 

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,0 +1,91 @@
+# Wiki Memory — Page Schema & Maintainer Instructions
+
+This is the contract for pages in a wiki-memory vault. The
+`OntologyEvaluator` enforces it on every write; agents maintaining a vault
+should follow it to avoid deny→retry cycles.
+
+## Vault layout (one per user)
+
+```
+<memory_root>/<user_id>/
+├── wiki/
+│   ├── index.md          # table of contents, maintained on every write
+│   ├── log.md            # append-only maintenance log
+│   └── <page-id>.md      # typed pages (kebab-case ids)
+└── raw/                  # ingested source material (read-only after ingest)
+```
+
+User scoping is absolute: tools resolve the vault from the caller's
+`CallerContext`; cross-user reads and writes are denied by policy and by a
+path-boundary check.
+
+## Frontmatter contract
+
+Every page under `wiki/` (except `index.md` and `log.md`) starts with YAML
+frontmatter:
+
+```yaml
+---
+id: go-worker-pools            # kebab-case, unique per user vault, == filename
+type: sw:Skill                 # CURIE of a class from the T-box (required)
+labels: ["Worker Pools", "worker pool pattern"]
+topics: [twitch:Go, twitch:Concurrency]   # SKOS concepts from twitch_topics.ttl
+links:
+  - {pred: sw:requiresPrerequisite, target: goroutines}
+  - {pred: skos:related, target: channels}
+claims:
+  - {id: c1, text: "Bounded worker pools prevent goroutine leaks under load",
+     sources: [src-pprof-talk], confidence: null}   # confidence written by inference, never by hand
+sources: [src-pprof-talk, src-go-blog-pipelines]
+updated: 2026-07-30
+---
+```
+
+Rules:
+
+- `id` — kebab-case (`^[a-z0-9]+(-[a-z0-9]+)*$`), unique in the vault, must
+  equal the filename without `.md`.
+- `type` — a CURIE naming a class that exists in the T-box. Unknown classes
+  are DENIED; the diagnostic lists nearest valid terms. If no class fits,
+  add an entry to `SCHEMA_GAPS.md` — never invent terms.
+- `links[].pred` — a property from the T-box with compatible domain/range
+  for the source and target page types. `links[].target` is a page id in
+  the same vault.
+- `claims[].id` — unique within the page; referenced by the inference
+  engine. `confidence` is owned by inference (leave `null` on write);
+  `contested: true` is set when a confident opposing claim exists.
+- `sources` — ids of entries under `raw/`.
+- `updated` — ISO date of last substantive edit.
+
+## Prefixes
+
+| Prefix   | Namespace                              | Source                                  |
+|----------|----------------------------------------|-----------------------------------------|
+| `sw:`    | `http://soypete.tech/l2ws/`            | `ontologies/education/TBOX_LEARNING_SOFTWARE.ttl` |
+| `twitch:`| `http://soypete.tech/twitch/topics/`   | `ontologies/social/twitch_topics.ttl`   |
+| `skos:`  | `http://www.w3.org/2004/02/skos/core#` | SKOS core                               |
+
+## Typed links in prose
+
+- `[[target|pred=sw:buildsToward]]` — typed wikilink.
+- `[[target]]` — bare link, defaults to `skos:related`.
+
+Both forms are extracted and validated exactly like frontmatter `links`.
+
+## Ingest workflow
+
+1. Store the source verbatim under `raw/` with an id (`src-...`).
+2. Match topics against SKOS prefLabel/altLabel (e.g. "Golang" → `twitch:Go`).
+3. Create or update pages through `memory_write_page` (the enforced path —
+   never write files directly). On DENY, read the structured diagnostics,
+   correct the page, and retry.
+4. Record claims with their sources; leave `confidence` null.
+5. Update `index.md` and append a line to `log.md`.
+6. Run `memory_lint` and fix what it reports.
+
+## The T-box is read-only
+
+Missing classes or predicates are recorded in `SCHEMA_GAPS.md` at the repo
+root. The ontology is a parameter of `WikiMemory` — this repo's vendored
+`ontologies/` submodule is the default, but any T-box with the same shape
+can be supplied.

--- a/SCHEMA_GAPS.md
+++ b/SCHEMA_GAPS.md
@@ -1,0 +1,10 @@
+# Schema Gaps
+
+Classes or predicates that memory content needed but the T-box
+(`github.com/Soypete/ontologies`) does not define. The T-box is read-only
+from this repo: gaps are recorded here and raised upstream, never invented
+locally.
+
+Format: `- [date] <needed term> — <why> — <workaround used>`
+
+(none yet)

--- a/go/cmd/memctl/main.go
+++ b/go/cmd/memctl/main.go
@@ -1,0 +1,148 @@
+// memctl is a development/CI tool for wiki memory. It is not part of the
+// SDK surface (Go module API, MCP tools, Python/TS SDKs) — it exists so CI
+// and humans can run the same validation rules the middleware enforces.
+//
+// Usage:
+//
+//	memctl lint -tbox <file.ttl> [-tbox ...] <wiki-dir>
+//
+// lint exits 1 if any page violates the frontmatter contract or the T-box,
+// or if the vault's merged A-box fails the SKOS structural checks.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/soypete/ontology-go/types"
+
+	"github.com/soypete/pedro-agentware/go/memory/ontology"
+	"github.com/soypete/pedro-agentware/go/memory/page"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
+	switch os.Args[1] {
+	case "lint":
+		os.Exit(lint(os.Args[2:]))
+	default:
+		usage()
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: memctl lint -tbox <file.ttl> [-tbox ...] <wiki-dir>")
+	os.Exit(2)
+}
+
+type tboxPaths []string
+
+func (t *tboxPaths) String() string     { return strings.Join(*t, ",") }
+func (t *tboxPaths) Set(v string) error { *t = append(*t, v); return nil }
+
+func lint(args []string) int {
+	fs := flag.NewFlagSet("lint", flag.ExitOnError)
+	var paths tboxPaths
+	fs.Var(&paths, "tbox", "T-box Turtle file (repeatable)")
+	_ = fs.Parse(args)
+	if fs.NArg() != 1 || len(paths) == 0 {
+		usage()
+	}
+	wikiDir := fs.Arg(0)
+
+	tbox, err := ontology.Load(paths...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	pages, failures := loadPages(wikiDir)
+	pageTypes := make(map[string]string, len(pages))
+	for id, p := range pages {
+		pageTypes[id] = p.Type
+	}
+	resolve := func(id string) (string, bool) {
+		t, ok := pageTypes[id]
+		return t, ok
+	}
+
+	for id, p := range pages {
+		for _, v := range tbox.ValidatePage(p, resolve, nil) {
+			failures++
+			fmt.Printf("%s.md: %s\n", id, v)
+		}
+	}
+
+	violations, err := ontology.CheckSKOSGraph(context.Background(), mergedABox(pages))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	for _, v := range violations {
+		failures++
+		fmt.Printf("vault: %s\n", v)
+	}
+
+	if failures > 0 {
+		fmt.Printf("memctl lint: %d violation(s)\n", failures)
+		return 1
+	}
+	fmt.Printf("memctl lint: %d page(s) clean\n", len(pages))
+	return 0
+}
+
+func loadPages(wikiDir string) (map[string]*page.Page, int) {
+	pages := make(map[string]*page.Page)
+	failures := 0
+	entries, err := os.ReadDir(wikiDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".md") ||
+			name == "index.md" || name == "log.md" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(wikiDir, name))
+		if err != nil {
+			fmt.Printf("%s: %v\n", name, err)
+			failures++
+			continue
+		}
+		p, err := page.Parse(data)
+		if err != nil {
+			fmt.Printf("%s: %v\n", name, err)
+			failures++
+			continue
+		}
+		id := strings.TrimSuffix(name, ".md")
+		if p.ID != id {
+			fmt.Printf("%s: frontmatter id %q does not match filename\n", name, p.ID)
+			failures++
+			continue
+		}
+		pages[id] = p
+	}
+	return pages, failures
+}
+
+func mergedABox(pages map[string]*page.Page) []types.Triple {
+	var all []types.Triple
+	for _, p := range pages {
+		triples, err := p.Triples("", nil)
+		if err != nil {
+			// Unknown-prefix errors are already reported by ValidatePage.
+			continue
+		}
+		all = append(all, triples...)
+	}
+	return all
+}

--- a/go/cmd/memctl/main.go
+++ b/go/cmd/memctl/main.go
@@ -20,8 +20,12 @@ import (
 
 	"github.com/soypete/ontology-go/types"
 
+	"github.com/soypete/pedro-agentware/go/mcp"
+	"github.com/soypete/pedro-agentware/go/memory"
 	"github.com/soypete/pedro-agentware/go/memory/ontology"
 	"github.com/soypete/pedro-agentware/go/memory/page"
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
 )
 
 func main() {
@@ -31,14 +35,52 @@ func main() {
 	switch os.Args[1] {
 	case "lint":
 		os.Exit(lint(os.Args[2:]))
+	case "serve":
+		os.Exit(serve(os.Args[2:]))
 	default:
 		usage()
 	}
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: memctl lint -tbox <file.ttl> [-tbox ...] <wiki-dir>")
+	fmt.Fprintln(os.Stderr, `usage:
+  memctl lint  -tbox <file.ttl> [-tbox ...] <wiki-dir>
+  memctl serve -tbox <file.ttl> [-tbox ...] -root <memory-root> -user <user-id> [-session <id>]`)
 	os.Exit(2)
+}
+
+// serve exposes the memory tools as an MCP stdio server scoped to one user.
+// SDK clients spawn one process per principal; the user can never be
+// overridden in-band (the policy denies args.user_id).
+func serve(args []string) int {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	var paths tboxPaths
+	fs.Var(&paths, "tbox", "T-box Turtle file (repeatable)")
+	root := fs.String("root", "", "memory root directory")
+	user := fs.String("user", "", "vault owner (required)")
+	session := fs.String("session", "mcp", "session id for audit records")
+	_ = fs.Parse(args)
+	if *root == "" || *user == "" || len(paths) == 0 {
+		usage()
+	}
+	wiki, err := memory.Enable(memory.Config{Root: *root, TBoxPaths: paths})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	registry := tools.NewToolRegistry()
+	wiki.RegisterTools(registry)
+	server := mcp.NewServer(registry, middleware.CallerContext{
+		UserID:    *user,
+		SessionID: *session,
+		Source:    "mcp",
+		Trusted:   true,
+	})
+	if err := server.Serve(context.Background(), os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	return 0
 }
 
 type tboxPaths []string

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,6 +3,6 @@ module github.com/soypete/pedro-agentware/go
 go 1.26
 
 require (
-	github.com/soypete/ontology-go v0.0.0-20260730165556-4c8e635acec4
+	github.com/soypete/ontology-go v0.0.0-20260730193222-0c5ba6ae2cd5
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,8 @@
 module github.com/soypete/pedro-agentware/go
 
 go 1.26
+
+require (
+	github.com/soypete/ontology-go v0.0.0-20260602220716-6c3811fc5370
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,6 +3,6 @@ module github.com/soypete/pedro-agentware/go
 go 1.26
 
 require (
-	github.com/soypete/ontology-go v0.0.0-20260602220716-6c3811fc5370
+	github.com/soypete/ontology-go v0.0.0-20260730165556-4c8e635acec4
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-github.com/soypete/ontology-go v0.0.0-20260730165556-4c8e635acec4 h1:kcQsVxjmHayIQVp/AGSIKTVofuTMEmuNzyGkiUiB2uc=
-github.com/soypete/ontology-go v0.0.0-20260730165556-4c8e635acec4/go.mod h1:+BZoiJwLiTKf1T9tzoT37PDtuEXtrOZW6iUuY/CXPjU=
+github.com/soypete/ontology-go v0.0.0-20260730193222-0c5ba6ae2cd5 h1:4mePEU1WwbXK2MGIAcjOWX4gmNi261Go9QNg3sA6/mA=
+github.com/soypete/ontology-go v0.0.0-20260730193222-0c5ba6ae2cd5/go.mod h1:+BZoiJwLiTKf1T9tzoT37PDtuEXtrOZW6iUuY/CXPjU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-github.com/soypete/ontology-go v0.0.0-20260602220716-6c3811fc5370 h1:XNBXzAM1e3oqLrljvGoOJepliBVVIH17ipELGoO+2xc=
-github.com/soypete/ontology-go v0.0.0-20260602220716-6c3811fc5370/go.mod h1:+BZoiJwLiTKf1T9tzoT37PDtuEXtrOZW6iUuY/CXPjU=
+github.com/soypete/ontology-go v0.0.0-20260730165556-4c8e635acec4 h1:kcQsVxjmHayIQVp/AGSIKTVofuTMEmuNzyGkiUiB2uc=
+github.com/soypete/ontology-go v0.0.0-20260730165556-4c8e635acec4/go.mod h1:+BZoiJwLiTKf1T9tzoT37PDtuEXtrOZW6iUuY/CXPjU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,6 @@
+github.com/soypete/ontology-go v0.0.0-20260602220716-6c3811fc5370 h1:XNBXzAM1e3oqLrljvGoOJepliBVVIH17ipELGoO+2xc=
+github.com/soypete/ontology-go v0.0.0-20260602220716-6c3811fc5370/go.mod h1:+BZoiJwLiTKf1T9tzoT37PDtuEXtrOZW6iUuY/CXPjU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/mcp/protocol.go
+++ b/go/mcp/protocol.go
@@ -1,0 +1,78 @@
+// Package mcp implements a minimal MCP (Model Context Protocol) server over
+// JSON-RPC 2.0, per business/SDK_PLAN.md: the Go core is the engine and the
+// Python/TypeScript SDKs are clients speaking MCP over stdio.
+//
+// Supported methods: initialize, ping, tools/list, tools/call. Tools come
+// from a tools.ToolRegistry; every call executes with a fixed
+// CallerContext, so a server process is scoped to one principal (the SDK
+// spawns one subprocess per user/session).
+package mcp
+
+import "encoding/json"
+
+// ProtocolVersion is the MCP protocol revision this server implements.
+const ProtocolVersion = "2025-06-18"
+
+type request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+const (
+	codeParse          = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternal       = -32603
+)
+
+type initializeResult struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ServerInfo      serverInfo     `json:"serverInfo"`
+}
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type toolDescriptor struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type listToolsResult struct {
+	Tools []toolDescriptor `json:"tools"`
+}
+
+type callToolParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type callToolResult struct {
+	Content []contentBlock `json:"content"`
+	IsError bool           `json:"isError,omitempty"`
+}

--- a/go/mcp/server.go
+++ b/go/mcp/server.go
@@ -1,0 +1,140 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+// Server serves a tool registry over MCP. Every tools/call runs with the
+// configured CallerContext attached, so downstream middleware and executors
+// see a stable principal for the life of the process.
+type Server struct {
+	registry *tools.ToolRegistry
+	caller   middleware.CallerContext
+	name     string
+	version  string
+}
+
+// NewServer builds a server for registry, executing calls as caller.
+func NewServer(registry *tools.ToolRegistry, caller middleware.CallerContext) *Server {
+	return &Server{
+		registry: registry,
+		caller:   caller,
+		name:     "pedro-agentware",
+		version:  "0.1.0",
+	}
+}
+
+// Serve reads newline-delimited JSON-RPC requests from r and writes
+// responses to w until EOF. Notifications (no id) get no response.
+func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	enc := json.NewEncoder(w)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		resp := s.handle(ctx, line)
+		if resp == nil {
+			continue
+		}
+		if err := enc.Encode(resp); err != nil {
+			return fmt.Errorf("mcp: write response: %w", err)
+		}
+	}
+	return scanner.Err()
+}
+
+func (s *Server) handle(ctx context.Context, raw []byte) *response {
+	var req request
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return &response{JSONRPC: "2.0", Error: &rpcError{Code: codeParse, Message: err.Error()}}
+	}
+	if req.JSONRPC != "2.0" || req.Method == "" {
+		return &response{JSONRPC: "2.0", ID: req.ID,
+			Error: &rpcError{Code: codeInvalidRequest, Message: "expected jsonrpc 2.0 request"}}
+	}
+	isNotification := len(req.ID) == 0
+	var (
+		result any
+		rerr   *rpcError
+	)
+	switch req.Method {
+	case "initialize":
+		result = initializeResult{
+			ProtocolVersion: ProtocolVersion,
+			Capabilities:    map[string]any{"tools": map[string]any{}},
+			ServerInfo:      serverInfo{Name: s.name, Version: s.version},
+		}
+	case "ping":
+		result = map[string]any{}
+	case "notifications/initialized":
+		return nil
+	case "tools/list":
+		result = s.listTools()
+	case "tools/call":
+		result, rerr = s.callTool(ctx, req.Params)
+	default:
+		rerr = &rpcError{Code: codeMethodNotFound, Message: "unknown method " + req.Method}
+	}
+	if isNotification {
+		return nil
+	}
+	if rerr != nil {
+		return &response{JSONRPC: "2.0", ID: req.ID, Error: rerr}
+	}
+	return &response{JSONRPC: "2.0", ID: req.ID, Result: result}
+}
+
+func (s *Server) listTools() listToolsResult {
+	out := listToolsResult{Tools: []toolDescriptor{}}
+	schemas := s.registry.Schemas()
+	for _, t := range s.registry.All() {
+		schema, ok := schemas[t.Name()]
+		if !ok {
+			schema = map[string]any{"type": "object"}
+		}
+		out.Tools = append(out.Tools, toolDescriptor{
+			Name:        t.Name(),
+			Description: t.Description(),
+			InputSchema: schema,
+		})
+	}
+	return out
+}
+
+func (s *Server) callTool(ctx context.Context, params json.RawMessage) (any, *rpcError) {
+	var p callToolParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &rpcError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	tool, ok := s.registry.Get(p.Name)
+	if !ok {
+		return nil, &rpcError{Code: codeInvalidParams, Message: "unknown tool " + p.Name}
+	}
+	if p.Arguments == nil {
+		p.Arguments = map[string]any{}
+	}
+	ctx = middleware.WithCallerContext(ctx, s.caller)
+	res, err := tool.Execute(ctx, p.Arguments)
+	if err != nil {
+		return nil, &rpcError{Code: codeInternal, Message: err.Error()}
+	}
+	if !res.Success {
+		return callToolResult{
+			Content: []contentBlock{{Type: "text", Text: res.Error}},
+			IsError: true,
+		}, nil
+	}
+	return callToolResult{
+		Content: []contentBlock{{Type: "text", Text: res.Output}},
+	}, nil
+}

--- a/go/mcp/server_test.go
+++ b/go/mcp/server_test.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/soypete/pedro-agentware/go/memory"
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+const (
+	tboxEducation = "../../ontologies/education/TBOX_LEARNING_SOFTWARE.ttl"
+	tboxTopics    = "../../ontologies/social/twitch_topics.ttl"
+)
+
+func memoryServer(t *testing.T, user string) *Server {
+	t.Helper()
+	wiki, err := memory.Enable(memory.Config{
+		Root:      t.TempDir(),
+		TBoxPaths: []string{tboxEducation, tboxTopics},
+	})
+	if err != nil {
+		t.Skipf("T-box unavailable (run: git submodule update --init): %v", err)
+	}
+	registry := tools.NewToolRegistry()
+	wiki.RegisterTools(registry)
+	return NewServer(registry, middleware.CallerContext{
+		UserID: user, SessionID: "test", Trusted: true,
+	})
+}
+
+// drive sends newline-delimited requests and decodes one response per line.
+func drive(t *testing.T, s *Server, requests ...string) []map[string]any {
+	t.Helper()
+	var out strings.Builder
+	if err := s.Serve(context.Background(), strings.NewReader(strings.Join(requests, "\n")+"\n"), &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	var responses []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(out.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("bad response line %q: %v", line, err)
+		}
+		responses = append(responses, m)
+	}
+	return responses
+}
+
+func TestInitializeAndListTools(t *testing.T) {
+	s := memoryServer(t, "alice")
+	rs := drive(t, s,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	)
+	if len(rs) != 2 {
+		t.Fatalf("expected 2 responses (notification is silent), got %d", len(rs))
+	}
+	init := rs[0]["result"].(map[string]any)
+	if init["protocolVersion"] != ProtocolVersion {
+		t.Errorf("protocolVersion = %v", init["protocolVersion"])
+	}
+	list := rs[1]["result"].(map[string]any)["tools"].([]any)
+	if len(list) != 5 {
+		t.Fatalf("expected 5 memory tools, got %d", len(list))
+	}
+	names := map[string]bool{}
+	for _, tool := range list {
+		names[tool.(map[string]any)["name"].(string)] = true
+	}
+	for _, want := range memory.Tools() {
+		if !names[want] {
+			t.Errorf("missing tool %s in tools/list", want)
+		}
+	}
+}
+
+func TestCallToolWriteAndQueryRoundTrip(t *testing.T) {
+	s := memoryServer(t, "alice")
+	page := "---\nid: go-worker-pools\ntype: sw:Skill\nlabels: [\"Worker Pools\"]\n---\nBody.\n"
+	writeReq, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name":      memory.ToolWritePage,
+			"arguments": map[string]any{"content": page},
+		},
+	})
+	rs := drive(t, s,
+		string(writeReq),
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"memory_query","arguments":{"question":"worker"}}}`,
+	)
+	write := rs[0]["result"].(map[string]any)
+	if write["isError"] == true {
+		t.Fatalf("write errored: %v", write)
+	}
+	query := rs[1]["result"].(map[string]any)
+	text := query["content"].([]any)[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, "go-worker-pools") {
+		t.Errorf("query result missing page: %s", text)
+	}
+}
+
+func TestCallToolDenyIsToolError(t *testing.T) {
+	s := memoryServer(t, "alice")
+	bad, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name":      memory.ToolWritePage,
+			"arguments": map[string]any{"content": "---\nid: p-x\ntype: sw:Skil\n---\n"},
+		},
+	})
+	rs := drive(t, s, string(bad))
+	result := rs[0]["result"].(map[string]any)
+	if result["isError"] != true {
+		t.Fatalf("policy deny must surface as tool error, got %v", result)
+	}
+	text := result["content"].([]any)[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, "diagnostics: ") || !strings.Contains(text, "unknown-class") {
+		t.Errorf("deny text must carry diagnostics, got %s", text)
+	}
+}
+
+func TestUnknownMethodAndTool(t *testing.T) {
+	s := memoryServer(t, "alice")
+	rs := drive(t, s,
+		`{"jsonrpc":"2.0","id":1,"method":"bogus/method"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bogus_tool","arguments":{}}}`,
+	)
+	if rs[0]["error"] == nil || rs[1]["error"] == nil {
+		t.Errorf("expected rpc errors, got %v", rs)
+	}
+}

--- a/go/memory/doc.go
+++ b/go/memory/doc.go
@@ -1,0 +1,26 @@
+// Package memory implements wiki memory: an LLM-maintained,
+// ontology-constrained markdown wiki scoped per user, with a Markov link
+// network for claim confidence.
+//
+// Memory is a composable agentware capability, not a standalone product.
+// Every memory write passes through the same middleware chain as any tool
+// call: declarative policy rules (deny-by-default, caller checks, rate
+// limits) plus a semantic tier — an OntologyEvaluator implementing
+// middleware.PolicyEvaluator that validates page frontmatter and typed
+// links against a read-only T-box (github.com/Soypete/ontologies by
+// default, vendored at ontologies/ in this repo).
+//
+// On-disk layout, one vault per user:
+//
+//	<memory_root>/<user_id>/wiki/      typed frontmatter pages
+//	<memory_root>/<user_id>/wiki/index.md
+//	<memory_root>/<user_id>/wiki/log.md
+//	<memory_root>/<user_id>/raw/       ingested sources
+//
+// User scoping is load-bearing: every memory tool call resolves its vault
+// from the CallerContext, and cross-user access is rejected both by policy
+// rule and by a path-boundary check in the executor (defense in depth).
+//
+// The page schema (frontmatter contract, typed wikilink syntax, ingest
+// workflow) is documented in SCHEMA.md at the repository root.
+package memory

--- a/go/memory/evaluator.go
+++ b/go/memory/evaluator.go
@@ -1,0 +1,222 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/soypete/ontology-go/types"
+
+	"github.com/soypete/pedro-agentware/go/memory/ontology"
+	"github.com/soypete/pedro-agentware/go/memory/page"
+	"github.com/soypete/pedro-agentware/go/middleware"
+)
+
+const (
+	skosConceptIRI = "http://www.w3.org/2004/02/skos/core#Concept"
+	rdfTypeIRI     = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+)
+
+// VaultReader gives the evaluator read access to a user's existing pages so
+// it can range-check links and detect graph-level violations a new write
+// would introduce. The memory executor implements it; tests may fake it.
+type VaultReader interface {
+	// PageType returns the type CURIE of an existing page, if the page exists.
+	PageType(userID, pageID string) (string, bool)
+	// VaultTriples returns the merged A-box of the user's vault, excluding
+	// excludePageID (the page being rewritten).
+	VaultTriples(userID, excludePageID string) ([]types.Triple, error)
+}
+
+// OntologyEvaluator implements middleware.PolicyEvaluator for memory tools.
+// Evaluation is two-tier:
+//
+//  1. Declarative: the stock middleware Policy (deny-by-default, scope
+//     rules, per-rule rate limits).
+//  2. Semantic: for write tools, the page content in args["content"] is
+//     parsed and validated against the T-box, and the write is checked for
+//     SKOS violations it would introduce into the vault graph (cycles,
+//     broader/narrower inconsistency).
+//
+// DENY decisions embed structured diagnostics: Reason ends with a JSON
+// array of ontology.Violation after the "diagnostics:" marker, so calling
+// agents can self-correct and retry.
+type OntologyEvaluator struct {
+	tbox     *ontology.TBox
+	policy   *middleware.Policy
+	limiter  *middleware.RateLimiter
+	prefixes map[string]string
+	vault    VaultReader
+}
+
+// EvaluatorOption configures an OntologyEvaluator.
+type EvaluatorOption func(*OntologyEvaluator)
+
+// WithDeclarativePolicy replaces the embedded default policy.
+func WithDeclarativePolicy(p *middleware.Policy) EvaluatorOption {
+	return func(e *OntologyEvaluator) { e.policy = p }
+}
+
+// WithPrefixes replaces the default CURIE prefix map (SCHEMA.md).
+func WithPrefixes(prefixes map[string]string) EvaluatorOption {
+	return func(e *OntologyEvaluator) { e.prefixes = prefixes }
+}
+
+// WithVaultReader wires vault read access for range and graph checks.
+// Without it, those checks are skipped (existence/domain checks still run).
+func WithVaultReader(v VaultReader) EvaluatorOption {
+	return func(e *OntologyEvaluator) { e.vault = v }
+}
+
+// NewOntologyEvaluator builds the evaluator for a read-only T-box.
+func NewOntologyEvaluator(tbox *ontology.TBox, opts ...EvaluatorOption) *OntologyEvaluator {
+	e := &OntologyEvaluator{
+		tbox:     tbox,
+		policy:   DefaultPolicy(),
+		limiter:  middleware.NewRateLimiter(),
+		prefixes: page.DefaultPrefixes(),
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Evaluate implements middleware.PolicyEvaluator.
+func (e *OntologyEvaluator) Evaluate(toolName string, args map[string]any, caller middleware.CallerContext) middleware.Decision {
+	decision := e.policy.Evaluate(toolName, args, caller)
+	if decision.Action == middleware.ActionDeny {
+		return decision
+	}
+	if denied, d := e.rateLimited(decision, toolName, caller); denied {
+		return d
+	}
+	if !isWriteTool(toolName) {
+		return decision
+	}
+	return e.evaluateWrite(decision, args, caller)
+}
+
+func (e *OntologyEvaluator) rateLimited(d middleware.Decision, toolName string, caller middleware.CallerContext) (bool, middleware.Decision) {
+	// The stock policy engine matches rules but does not enforce MaxRate;
+	// apply the matched rule's limit here, keyed per user and tool.
+	for i := range e.policy.Rules {
+		rule := &e.policy.Rules[i]
+		if rule.Name != d.Rule {
+			continue
+		}
+		if rule.MaxRate == nil {
+			return false, d
+		}
+		key := caller.UserID + "|" + toolName
+		e.limiter.SetWindow(key, rule.MaxRate.Window)
+		if e.limiter.Allow(key, rule.MaxRate.Count) {
+			return false, d
+		}
+		return true, middleware.Decision{
+			Action: middleware.ActionDeny,
+			Rule:   rule.Name,
+			Reason: fmt.Sprintf("rate limit exceeded: %d calls per %s for %s",
+				rule.MaxRate.Count, rule.MaxRate.Window, toolName),
+			Timestamp: time.Now(),
+		}
+	}
+	return false, d
+}
+
+func (e *OntologyEvaluator) evaluateWrite(d middleware.Decision, args map[string]any, caller middleware.CallerContext) middleware.Decision {
+	content, ok := args["content"].(string)
+	if !ok || content == "" {
+		return denyDiagnostics(d.Rule, "write requires string args.content with page markdown", nil)
+	}
+	p, err := page.Parse([]byte(content))
+	if err != nil {
+		return denyDiagnostics(d.Rule, fmt.Sprintf("page contract violation: %v", err), nil)
+	}
+	if pageID, ok := args["page_id"].(string); ok && pageID != p.ID {
+		return denyDiagnostics(d.Rule,
+			fmt.Sprintf("args.page_id %q does not match frontmatter id %q", pageID, p.ID), nil)
+	}
+
+	var resolve ontology.TypeResolver
+	if e.vault != nil {
+		resolve = func(pageID string) (string, bool) {
+			return e.vault.PageType(caller.UserID, pageID)
+		}
+	}
+	violations := e.tbox.ValidatePage(p, resolve, e.prefixes)
+
+	if len(violations) == 0 && e.vault != nil {
+		graphViolations, err := e.graphCheck(p, caller.UserID)
+		if err != nil {
+			return denyDiagnostics(d.Rule, fmt.Sprintf("vault graph check failed: %v", err), nil)
+		}
+		violations = graphViolations
+	}
+	if len(violations) > 0 {
+		return denyDiagnostics(d.Rule,
+			fmt.Sprintf("ontology validation failed with %d violation(s)", len(violations)),
+			violations)
+	}
+	return d
+}
+
+// graphCheck validates the vault graph as it would exist after the write.
+// Page subjects are additionally typed skos:Concept in the candidate graph:
+// vault pages are the concepts of the user's scheme, and the upstream SKOS
+// checks seed their traversals from skos:Concept subjects.
+func (e *OntologyEvaluator) graphCheck(p *page.Page, userID string) ([]ontology.Violation, error) {
+	existing, err := e.vault.VaultTriples(userID, p.ID)
+	if err != nil {
+		return nil, err
+	}
+	newTriples, err := p.Triples("", e.prefixes)
+	if err != nil {
+		return nil, err
+	}
+	candidate := append(append([]types.Triple{}, existing...), newTriples...)
+	subjects := make(map[string]bool)
+	for _, t := range candidate {
+		subjects[t.Subject] = true
+	}
+	for subj := range subjects {
+		candidate = append(candidate, types.Triple{
+			Subject: subj, Predicate: rdfTypeIRI, Object: skosConceptIRI,
+		})
+	}
+	return ontology.CheckSKOSGraph(context.Background(), candidate)
+}
+
+// DiagnosticsMarker separates the human-readable reason from the JSON
+// diagnostics payload in DENY reasons.
+const DiagnosticsMarker = "diagnostics: "
+
+func denyDiagnostics(rule, reason string, violations []ontology.Violation) middleware.Decision {
+	if len(violations) > 0 {
+		if payload, err := json.Marshal(violations); err == nil {
+			reason += "; " + DiagnosticsMarker + string(payload)
+		}
+	}
+	return middleware.Decision{
+		Action:    middleware.ActionDeny,
+		Rule:      rule,
+		Reason:    reason,
+		Timestamp: time.Now(),
+	}
+}
+
+// ParseDiagnostics extracts the structured violations from a DENY reason
+// produced by this evaluator. ok is false if the reason carries none.
+func ParseDiagnostics(reason string) ([]ontology.Violation, bool) {
+	i := strings.Index(reason, DiagnosticsMarker)
+	if i < 0 {
+		return nil, false
+	}
+	var vs []ontology.Violation
+	if err := json.Unmarshal([]byte(reason[i+len(DiagnosticsMarker):]), &vs); err != nil {
+		return nil, false
+	}
+	return vs, true
+}

--- a/go/memory/evaluator.go
+++ b/go/memory/evaluator.go
@@ -93,7 +93,7 @@ func (e *OntologyEvaluator) Evaluate(toolName string, args map[string]any, calle
 	if denied, d := e.rateLimited(decision, toolName, caller); denied {
 		return d
 	}
-	if !isWriteTool(toolName) {
+	if !isSemanticWrite(toolName) {
 		return decision
 	}
 	return e.evaluateWrite(decision, args, caller)

--- a/go/memory/evaluator_test.go
+++ b/go/memory/evaluator_test.go
@@ -1,0 +1,216 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/soypete/ontology-go/types"
+
+	"github.com/soypete/pedro-agentware/go/memory/ontology"
+	"github.com/soypete/pedro-agentware/go/middleware"
+)
+
+const (
+	tboxEducation = "../../ontologies/education/TBOX_LEARNING_SOFTWARE.ttl"
+	tboxTopics    = "../../ontologies/social/twitch_topics.ttl"
+)
+
+func testTBox(t *testing.T) *ontology.TBox {
+	t.Helper()
+	tb, err := ontology.Load(tboxEducation, tboxTopics)
+	if err != nil {
+		t.Skipf("T-box fixtures unavailable (run: git submodule update --init): %v", err)
+	}
+	return tb
+}
+
+// fakeVault is an in-memory VaultReader: pageID -> (type CURIE, triples).
+type fakeVault struct {
+	users map[string]map[string]fakePage
+}
+
+type fakePage struct {
+	typeCURIE string
+	triples   []types.Triple
+}
+
+func (f *fakeVault) PageType(userID, pageID string) (string, bool) {
+	p, ok := f.users[userID][pageID]
+	return p.typeCURIE, ok
+}
+
+func (f *fakeVault) VaultTriples(userID, excludePageID string) ([]types.Triple, error) {
+	var out []types.Triple
+	for id, p := range f.users[userID] {
+		if id == excludePageID {
+			continue
+		}
+		out = append(out, p.triples...)
+	}
+	return out, nil
+}
+
+func alice() middleware.CallerContext {
+	return middleware.CallerContext{UserID: "alice", SessionID: "s1", Trusted: true}
+}
+
+func pageArgs(content string) map[string]any {
+	return map[string]any{"content": content}
+}
+
+const validWrite = `---
+id: go-worker-pools
+type: sw:Skill
+labels: ["Worker Pools"]
+topics: [twitch:Go]
+---
+Uses [[goroutines|pred=sw:requiresPrerequisite]].
+`
+
+func TestEvaluatorAllowsValidWrite(t *testing.T) {
+	vault := &fakeVault{users: map[string]map[string]fakePage{
+		"alice": {"goroutines": {typeCURIE: "sw:Skill"}},
+	}}
+	e := NewOntologyEvaluator(testTBox(t), WithVaultReader(vault))
+	d := e.Evaluate(ToolWritePage, pageArgs(validWrite), alice())
+	if d.Action != middleware.ActionAllow {
+		t.Fatalf("expected allow, got %s: %s", d.Action, d.Reason)
+	}
+}
+
+func TestEvaluatorDeniesUnknownClassWithNearestTerms(t *testing.T) {
+	e := NewOntologyEvaluator(testTBox(t))
+	content := "---\nid: x-page\ntype: sw:Skil\n---\n"
+	d := e.Evaluate(ToolWritePage, pageArgs(content), alice())
+	if d.Action != middleware.ActionDeny {
+		t.Fatalf("expected deny, got %s", d.Action)
+	}
+	vs, ok := ParseDiagnostics(d.Reason)
+	if !ok || len(vs) != 1 {
+		t.Fatalf("expected parseable diagnostics, got %q", d.Reason)
+	}
+	if vs[0].Constraint != ontology.ConstraintUnknownClass {
+		t.Errorf("expected unknown-class, got %s", vs[0].Constraint)
+	}
+	if len(vs[0].Nearest) == 0 || vs[0].Nearest[0] != "http://soypete.tech/l2ws/Skill" {
+		t.Errorf("expected sw:Skill as nearest term, got %v", vs[0].Nearest)
+	}
+}
+
+func TestEvaluatorDeniesCycleIntroducingLink(t *testing.T) {
+	// Existing vault: a-page --skos:broader--> b-page. Writing b-page with
+	// skos:broader a-page closes a cycle and must be denied.
+	base := "http://soypete.tech/memory/"
+	vault := &fakeVault{users: map[string]map[string]fakePage{
+		"alice": {
+			"a-page": {typeCURIE: "sw:Skill", triples: []types.Triple{
+				{Subject: base + "a-page", Predicate: "http://www.w3.org/2004/02/skos/core#broader", Object: base + "b-page"},
+			}},
+			"b-page": {typeCURIE: "sw:Skill"},
+		},
+	}}
+	e := NewOntologyEvaluator(testTBox(t), WithVaultReader(vault))
+	content := "---\nid: b-page\ntype: sw:Skill\nlinks:\n  - {pred: skos:broader, target: a-page}\n---\n"
+	d := e.Evaluate(ToolWritePage, pageArgs(content), alice())
+	if d.Action != middleware.ActionDeny {
+		t.Fatalf("expected deny for cycle-introducing link, got %s: %s", d.Action, d.Reason)
+	}
+	vs, ok := ParseDiagnostics(d.Reason)
+	if !ok {
+		t.Fatalf("expected diagnostics, got %q", d.Reason)
+	}
+	found := false
+	for _, v := range vs {
+		if v.Constraint == ontology.ConstraintSKOSCycle {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected %s violation, got %v", ontology.ConstraintSKOSCycle, vs)
+	}
+}
+
+func TestEvaluatorDeniesAnonymousAndScopeOverride(t *testing.T) {
+	e := NewOntologyEvaluator(testTBox(t))
+	if d := e.Evaluate(ToolQuery, map[string]any{}, middleware.CallerContext{}); d.Action != middleware.ActionDeny {
+		t.Errorf("anonymous caller must be denied, got %s", d.Action)
+	}
+	args := map[string]any{"user_id": "bob"}
+	if d := e.Evaluate(ToolQuery, args, alice()); d.Action != middleware.ActionDeny {
+		t.Errorf("scope-override arg must be denied, got %s", d.Action)
+	} else if d.Rule != "memory-deny-scope-override" {
+		t.Errorf("expected scope-override rule, got %s", d.Rule)
+	}
+}
+
+func TestEvaluatorDefaultDenyUnknownTool(t *testing.T) {
+	e := NewOntologyEvaluator(testTBox(t))
+	if d := e.Evaluate("delete_database", nil, alice()); d.Action != middleware.ActionDeny {
+		t.Errorf("non-memory tool must hit default deny, got %s", d.Action)
+	}
+}
+
+func TestEvaluatorRateLimit(t *testing.T) {
+	policy := DefaultPolicy()
+	// Tighten the read rule to 3/min for the test.
+	for i := range policy.Rules {
+		if policy.Rules[i].Name == "memory-reads" {
+			policy.Rules[i].MaxRate.Count = 3
+		}
+	}
+	e := NewOntologyEvaluator(testTBox(t), WithDeclarativePolicy(policy))
+	for i := range 3 {
+		if d := e.Evaluate(ToolQuery, nil, alice()); d.Action != middleware.ActionAllow {
+			t.Fatalf("call %d should be allowed, got %s: %s", i+1, d.Action, d.Reason)
+		}
+	}
+	d := e.Evaluate(ToolQuery, nil, alice())
+	if d.Action != middleware.ActionDeny || !strings.Contains(d.Reason, "rate limit") {
+		t.Errorf("4th call must be rate-limited, got %s: %s", d.Action, d.Reason)
+	}
+	// Other users are unaffected (limits are per user+tool).
+	bob := middleware.CallerContext{UserID: "bob", SessionID: "s2"}
+	if d := e.Evaluate(ToolQuery, nil, bob); d.Action != middleware.ActionAllow {
+		t.Errorf("bob must not share alice's rate bucket, got %s", d.Action)
+	}
+}
+
+func TestEvaluatorPageIDMismatch(t *testing.T) {
+	e := NewOntologyEvaluator(testTBox(t))
+	args := pageArgs(validWrite)
+	args["page_id"] = "other-page"
+	d := e.Evaluate(ToolWritePage, args, alice())
+	if d.Action != middleware.ActionDeny || !strings.Contains(d.Reason, "does not match") {
+		t.Errorf("expected page_id mismatch deny, got %s: %s", d.Action, d.Reason)
+	}
+}
+
+func TestDefaultPolicyParses(t *testing.T) {
+	p := DefaultPolicy()
+	if !p.DefaultDeny || len(p.Rules) != 4 {
+		t.Errorf("unexpected default policy shape: defaultDeny=%v rules=%d", p.DefaultDeny, len(p.Rules))
+	}
+	for _, name := range []string{"memory-deny-scope-override", "memory-deny-anonymous", "memory-writes", "memory-reads"} {
+		found := false
+		for _, r := range p.Rules {
+			if r.Name == name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing rule %s", name)
+		}
+	}
+}
+
+func TestParseDiagnosticsRoundTrip(t *testing.T) {
+	vs := []ontology.Violation{{Constraint: "unknown-class", Term: "sw:Skil", Message: "m", Nearest: []string{"a"}}}
+	d := denyDiagnostics("r", "ontology validation failed", vs)
+	got, ok := ParseDiagnostics(d.Reason)
+	if !ok || len(got) != 1 || got[0].Constraint != "unknown-class" {
+		t.Errorf("round trip failed: %v %v", got, ok)
+	}
+	if _, ok := ParseDiagnostics("no marker here"); ok {
+		t.Error("expected no diagnostics")
+	}
+}

--- a/go/memory/executor.go
+++ b/go/memory/executor.go
@@ -62,7 +62,7 @@ func (x *Executor) Execute(ctx context.Context, toolName string, args map[string
 	case ToolGetClaims:
 		return x.getClaims(userID, args)
 	case ToolLint:
-		return x.lint(userID)
+		return x.lint(userID, args)
 	default:
 		return &tools.Result{Success: false, Error: "unknown memory tool: " + toolName}, nil
 	}
@@ -175,7 +175,19 @@ func (x *Executor) getClaims(userID string, args map[string]any) (*tools.Result,
 	return jsonResult(out)
 }
 
-func (x *Executor) lint(userID string) (*tools.Result, error) {
+// Lint-only constraint identifiers (write-time enforcement never blocks on
+// these; they are hygiene findings for the maintaining agent).
+const (
+	LintDanglingLink     = "dangling-link"
+	LintOrphanPage       = "orphan-page"
+	LintStalePage        = "stale-page"
+	LintMissingTypedLink = "missing-typed-links"
+)
+
+// defaultStaleDays is the lint threshold for the `updated` frontmatter date.
+const defaultStaleDays = 90
+
+func (x *Executor) lint(userID string, args map[string]any) (*tools.Result, error) {
 	pages, err := x.pages(userID)
 	if err != nil {
 		return nil, err
@@ -188,12 +200,24 @@ func (x *Executor) lint(userID string) (*tools.Result, error) {
 		}
 		return "", false
 	}
+	staleDays := defaultStaleDays
+	if d, ok := args["stale_days"].(float64); ok && d > 0 {
+		staleDays = int(d)
+	}
+	staleBefore := time.Now().AddDate(0, 0, -staleDays)
+
 	type lintIssue struct {
 		Page      string `json:"page,omitempty"`
 		Violation ontology.Violation
 	}
 	issues := []lintIssue{}
 	var abox []types.Triple
+	incoming := map[string]bool{}
+	for _, p := range pages {
+		for _, link := range p.AllLinks() {
+			incoming[link.Target] = true
+		}
+	}
 	for _, p := range pages {
 		for _, v := range x.tbox.ValidatePage(p, resolve, x.prefixes) {
 			issues = append(issues, lintIssue{Page: p.ID, Violation: v})
@@ -201,12 +225,39 @@ func (x *Executor) lint(userID string) (*tools.Result, error) {
 		if triples, err := p.Triples("", x.prefixes); err == nil {
 			abox = append(abox, triples...)
 		}
+		typedLinks := 0
 		for _, link := range p.AllLinks() {
 			if _, ok := resolve(link.Target); !ok {
 				issues = append(issues, lintIssue{Page: p.ID, Violation: ontology.Violation{
-					Constraint: "dangling-link",
+					Constraint: LintDanglingLink,
 					Term:       link.Target,
-					Message:    fmt.Sprintf("link target %q has no page", link.Target),
+					Message:    fmt.Sprintf("link target %q is mentioned but has no page", link.Target),
+				}})
+			}
+			if link.Pred != page.DefaultLinkPred {
+				typedLinks++
+			}
+		}
+		if len(pages) > 1 && !incoming[p.ID] && len(p.AllLinks()) == 0 {
+			issues = append(issues, lintIssue{Page: p.ID, Violation: ontology.Violation{
+				Constraint: LintOrphanPage,
+				Term:       p.ID,
+				Message:    "page has no links in or out",
+			}})
+		}
+		if typedLinks == 0 && len(p.AllLinks()) > 0 {
+			issues = append(issues, lintIssue{Page: p.ID, Violation: ontology.Violation{
+				Constraint: LintMissingTypedLink,
+				Term:       p.ID,
+				Message:    "page links only via bare skos:related; add typed predicates",
+			}})
+		}
+		if p.Updated != "" {
+			if updated, err := time.Parse("2006-01-02", p.Updated); err == nil && updated.Before(staleBefore) {
+				issues = append(issues, lintIssue{Page: p.ID, Violation: ontology.Violation{
+					Constraint: LintStalePage,
+					Term:       p.ID,
+					Message:    fmt.Sprintf("last updated %s (over %d days ago)", p.Updated, staleDays),
 				}})
 			}
 		}

--- a/go/memory/executor.go
+++ b/go/memory/executor.go
@@ -143,7 +143,7 @@ func (x *Executor) query(userID string, args map[string]any) (*tools.Result, err
 		Type   string   `json:"type"`
 		Labels []string `json:"labels,omitempty"`
 	}
-	var hits []hit
+	hits := []hit{}
 	for _, p := range pages {
 		haystack := strings.ToLower(p.ID + " " + strings.Join(p.Labels, " ") + " " + strings.Join(p.Topics, " "))
 		for word := range strings.FieldsSeq(q) {
@@ -171,7 +171,7 @@ func (x *Executor) getClaims(userID string, args map[string]any) (*tools.Result,
 		Confidence *float64 `json:"confidence"`
 		Contested  bool     `json:"contested,omitempty"`
 	}
-	var out []claimOut
+	out := []claimOut{}
 	for _, p := range pages {
 		if wantPage != "" && p.ID != wantPage {
 			continue
@@ -207,7 +207,7 @@ func (x *Executor) lint(userID string) (*tools.Result, error) {
 		Page      string `json:"page,omitempty"`
 		Violation ontology.Violation
 	}
-	var issues []lintIssue
+	issues := []lintIssue{}
 	var abox []types.Triple
 	for _, p := range pages {
 		for _, v := range x.tbox.ValidatePage(p, resolve, x.prefixes) {

--- a/go/memory/executor.go
+++ b/go/memory/executor.go
@@ -1,0 +1,358 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/soypete/ontology-go/types"
+
+	"github.com/soypete/pedro-agentware/go/memory/ontology"
+	"github.com/soypete/pedro-agentware/go/memory/page"
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+// ErrNoCaller reports a memory tool call with no caller in the context.
+// The declarative policy denies these before execution; the executor
+// re-checks as defense in depth.
+var ErrNoCaller = errors.New("memory: no caller context")
+
+// Executor executes the memory tools against a per-user vault. It
+// implements middleware.ToolExecutor and VaultReader. It performs no policy
+// evaluation itself, but every filesystem path is re-checked against the
+// caller's vault boundary (defense in depth alongside the policy tier).
+type Executor struct {
+	vault    *Vault
+	tbox     *ontology.TBox
+	prefixes map[string]string
+}
+
+// NewExecutor builds an Executor over vault, validating reads against tbox.
+func NewExecutor(vault *Vault, tbox *ontology.TBox, prefixes map[string]string) *Executor {
+	if prefixes == nil {
+		prefixes = page.DefaultPrefixes()
+	}
+	return &Executor{vault: vault, tbox: tbox, prefixes: prefixes}
+}
+
+// Execute implements middleware.ToolExecutor.
+func (x *Executor) Execute(ctx context.Context, toolName string, args map[string]any) (*tools.Result, error) {
+	caller, ok := middleware.CallerFromContext(ctx)
+	if !ok || caller.UserID == "" {
+		return nil, ErrNoCaller
+	}
+	userID := caller.UserID
+	if err := x.vault.EnsureUser(userID); err != nil {
+		return nil, err
+	}
+	switch toolName {
+	case ToolWritePage:
+		return x.writePage(userID, args)
+	case ToolIngest:
+		return x.ingest(userID, args)
+	case ToolQuery:
+		return x.query(userID, args)
+	case ToolGetClaims:
+		return x.getClaims(userID, args)
+	case ToolLint:
+		return x.lint(userID)
+	default:
+		return &tools.Result{Success: false, Error: "unknown memory tool: " + toolName}, nil
+	}
+}
+
+func stringArg(args map[string]any, key string) string {
+	s, _ := args[key].(string)
+	return s
+}
+
+func (x *Executor) writePage(userID string, args map[string]any) (*tools.Result, error) {
+	content := stringArg(args, "content")
+	p, err := page.Parse([]byte(content))
+	if err != nil {
+		return &tools.Result{Success: false, Error: err.Error()}, nil
+	}
+	path, err := x.vault.PagePath(userID, p.ID)
+	if err != nil {
+		return &tools.Result{Success: false, Error: err.Error()}, nil
+	}
+	if !x.vault.Contains(userID, path) {
+		return nil, fmt.Errorf("%w: %s", ErrOutsideVault, path)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return nil, fmt.Errorf("memory: write page: %w", err)
+	}
+	if err := x.refreshIndex(userID); err != nil {
+		return nil, err
+	}
+	if err := x.appendLog(userID, "wrote page "+p.ID); err != nil {
+		return nil, err
+	}
+	return &tools.Result{
+		Success:       true,
+		Output:        "wrote " + p.ID,
+		ModifiedFiles: []string{path},
+	}, nil
+}
+
+func (x *Executor) ingest(userID string, args map[string]any) (*tools.Result, error) {
+	sourceID := stringArg(args, "source_id")
+	text := stringArg(args, "text")
+	if !pageIDPattern.MatchString(sourceID) {
+		return &tools.Result{Success: false,
+			Error: fmt.Sprintf("memory: source_id %q is not kebab-case", sourceID)}, nil
+	}
+	if strings.TrimSpace(text) == "" {
+		return &tools.Result{Success: false, Error: "memory: ingest requires args.text"}, nil
+	}
+	raw, err := x.vault.RawDir(userID)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(raw, sourceID+".md")
+	if !x.vault.Contains(userID, path) {
+		return nil, fmt.Errorf("%w: %s", ErrOutsideVault, path)
+	}
+	if err := os.WriteFile(path, []byte(text), 0o644); err != nil {
+		return nil, fmt.Errorf("memory: write source: %w", err)
+	}
+	if err := x.appendLog(userID, "ingested source "+sourceID); err != nil {
+		return nil, err
+	}
+	return &tools.Result{Success: true, Output: "ingested " + sourceID,
+		ModifiedFiles: []string{path}}, nil
+}
+
+// query is the v1 surface: keyword match over page ids, labels, and topics.
+// Phase 5 replaces this with competency-question support.
+func (x *Executor) query(userID string, args map[string]any) (*tools.Result, error) {
+	q := strings.ToLower(stringArg(args, "question"))
+	pages, err := x.pages(userID)
+	if err != nil {
+		return nil, err
+	}
+	type hit struct {
+		ID     string   `json:"id"`
+		Type   string   `json:"type"`
+		Labels []string `json:"labels,omitempty"`
+	}
+	var hits []hit
+	for _, p := range pages {
+		haystack := strings.ToLower(p.ID + " " + strings.Join(p.Labels, " ") + " " + strings.Join(p.Topics, " "))
+		for word := range strings.FieldsSeq(q) {
+			if strings.Contains(haystack, word) {
+				hits = append(hits, hit{ID: p.ID, Type: p.Type, Labels: p.Labels})
+				break
+			}
+		}
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].ID < hits[j].ID })
+	return jsonResult(hits)
+}
+
+func (x *Executor) getClaims(userID string, args map[string]any) (*tools.Result, error) {
+	wantPage := stringArg(args, "page_id")
+	pages, err := x.pages(userID)
+	if err != nil {
+		return nil, err
+	}
+	type claimOut struct {
+		Page       string   `json:"page"`
+		ID         string   `json:"id"`
+		Text       string   `json:"text"`
+		Sources    []string `json:"sources,omitempty"`
+		Confidence *float64 `json:"confidence"`
+		Contested  bool     `json:"contested,omitempty"`
+	}
+	var out []claimOut
+	for _, p := range pages {
+		if wantPage != "" && p.ID != wantPage {
+			continue
+		}
+		for _, c := range p.Claims {
+			out = append(out, claimOut{Page: p.ID, ID: c.ID, Text: c.Text,
+				Sources: c.Sources, Confidence: c.Confidence, Contested: c.Contested})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Page != out[j].Page {
+			return out[i].Page < out[j].Page
+		}
+		return out[i].ID < out[j].ID
+	})
+	return jsonResult(out)
+}
+
+func (x *Executor) lint(userID string) (*tools.Result, error) {
+	pages, err := x.pages(userID)
+	if err != nil {
+		return nil, err
+	}
+	resolve := func(id string) (string, bool) {
+		for _, p := range pages {
+			if p.ID == id {
+				return p.Type, true
+			}
+		}
+		return "", false
+	}
+	type lintIssue struct {
+		Page      string `json:"page,omitempty"`
+		Violation ontology.Violation
+	}
+	var issues []lintIssue
+	var abox []types.Triple
+	for _, p := range pages {
+		for _, v := range x.tbox.ValidatePage(p, resolve, x.prefixes) {
+			issues = append(issues, lintIssue{Page: p.ID, Violation: v})
+		}
+		if triples, err := p.Triples("", x.prefixes); err == nil {
+			abox = append(abox, triples...)
+		}
+		for _, link := range p.AllLinks() {
+			if _, ok := resolve(link.Target); !ok {
+				issues = append(issues, lintIssue{Page: p.ID, Violation: ontology.Violation{
+					Constraint: "dangling-link",
+					Term:       link.Target,
+					Message:    fmt.Sprintf("link target %q has no page", link.Target),
+				}})
+			}
+		}
+	}
+	graphViolations, err := ontology.CheckSKOSGraph(context.Background(), abox)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range graphViolations {
+		issues = append(issues, lintIssue{Violation: v})
+	}
+	return jsonResult(issues)
+}
+
+// PageType implements VaultReader.
+func (x *Executor) PageType(userID, pageID string) (string, bool) {
+	p, err := x.readPage(userID, pageID)
+	if err != nil {
+		return "", false
+	}
+	return p.Type, true
+}
+
+// VaultTriples implements VaultReader.
+func (x *Executor) VaultTriples(userID, excludePageID string) ([]types.Triple, error) {
+	pages, err := x.pages(userID)
+	if err != nil {
+		return nil, err
+	}
+	var all []types.Triple
+	for _, p := range pages {
+		if p.ID == excludePageID {
+			continue
+		}
+		triples, err := p.Triples("", x.prefixes)
+		if err != nil {
+			continue
+		}
+		all = append(all, triples...)
+	}
+	return all, nil
+}
+
+func (x *Executor) readPage(userID, pageID string) (*page.Page, error) {
+	path, err := x.vault.PagePath(userID, pageID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return page.Parse(data)
+}
+
+// pages parses every page in the user's wiki, skipping index.md, log.md,
+// and unparseable files (memory_lint reports those separately).
+func (x *Executor) pages(userID string) ([]*page.Page, error) {
+	wiki, err := x.vault.WikiDir(userID)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(wiki)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var pages []*page.Page
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".md") || name == "index.md" || name == "log.md" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(wiki, name))
+		if err != nil {
+			continue
+		}
+		p, err := page.Parse(data)
+		if err != nil {
+			continue
+		}
+		pages = append(pages, p)
+	}
+	sort.Slice(pages, func(i, j int) bool { return pages[i].ID < pages[j].ID })
+	return pages, nil
+}
+
+func (x *Executor) refreshIndex(userID string) error {
+	pages, err := x.pages(userID)
+	if err != nil {
+		return err
+	}
+	var sb strings.Builder
+	sb.WriteString("# Wiki Index\n\n")
+	if len(pages) == 0 {
+		sb.WriteString("No pages yet.\n")
+	}
+	for _, p := range pages {
+		label := p.ID
+		if len(p.Labels) > 0 {
+			label = p.Labels[0]
+		}
+		fmt.Fprintf(&sb, "- [%s](%s.md) — %s\n", label, p.ID, p.Type)
+	}
+	wiki, err := x.vault.WikiDir(userID)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(wiki, "index.md"), []byte(sb.String()), 0o644)
+}
+
+func (x *Executor) appendLog(userID, entry string) error {
+	wiki, err := x.vault.WikiDir(userID)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(filepath.Join(wiki, "log.md"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = fmt.Fprintf(f, "- [%s] %s\n", time.Now().UTC().Format("2006-01-02 15:04:05"), entry)
+	return err
+}
+
+func jsonResult(v any) (*tools.Result, error) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return &tools.Result{Success: true, Output: string(data)}, nil
+}

--- a/go/memory/executor.go
+++ b/go/memory/executor.go
@@ -164,12 +164,14 @@ func (x *Executor) getClaims(userID string, args map[string]any) (*tools.Result,
 		return nil, err
 	}
 	type claimOut struct {
-		Page       string   `json:"page"`
-		ID         string   `json:"id"`
-		Text       string   `json:"text"`
-		Sources    []string `json:"sources,omitempty"`
-		Confidence *float64 `json:"confidence"`
-		Contested  bool     `json:"contested,omitempty"`
+		Page        string   `json:"page"`
+		ID          string   `json:"id"`
+		Text        string   `json:"text"`
+		Sources     []string `json:"sources,omitempty"`
+		Supports    []string `json:"supports,omitempty"`
+		Contradicts []string `json:"contradicts,omitempty"`
+		Confidence  *float64 `json:"confidence"`
+		Contested   bool     `json:"contested,omitempty"`
 	}
 	out := []claimOut{}
 	for _, p := range pages {
@@ -178,7 +180,8 @@ func (x *Executor) getClaims(userID string, args map[string]any) (*tools.Result,
 		}
 		for _, c := range p.Claims {
 			out = append(out, claimOut{Page: p.ID, ID: c.ID, Text: c.Text,
-				Sources: c.Sources, Confidence: c.Confidence, Contested: c.Contested})
+				Sources: c.Sources, Supports: c.Supports, Contradicts: c.Contradicts,
+				Confidence: c.Confidence, Contested: c.Contested})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/go/memory/executor.go
+++ b/go/memory/executor.go
@@ -130,31 +130,13 @@ func (x *Executor) ingest(userID string, args map[string]any) (*tools.Result, er
 		ModifiedFiles: []string{path}}, nil
 }
 
-// query is the v1 surface: keyword match over page ids, labels, and topics.
-// Phase 5 replaces this with competency-question support.
+// query answers competency questions via args.kind (see query.go) or falls
+// back to keyword matching over args.question.
 func (x *Executor) query(userID string, args map[string]any) (*tools.Result, error) {
-	q := strings.ToLower(stringArg(args, "question"))
-	pages, err := x.pages(userID)
-	if err != nil {
-		return nil, err
+	if kind := stringArg(args, "kind"); kind != "" {
+		return x.structuredQuery(userID, kind, args)
 	}
-	type hit struct {
-		ID     string   `json:"id"`
-		Type   string   `json:"type"`
-		Labels []string `json:"labels,omitempty"`
-	}
-	hits := []hit{}
-	for _, p := range pages {
-		haystack := strings.ToLower(p.ID + " " + strings.Join(p.Labels, " ") + " " + strings.Join(p.Topics, " "))
-		for word := range strings.FieldsSeq(q) {
-			if strings.Contains(haystack, word) {
-				hits = append(hits, hit{ID: p.ID, Type: p.Type, Labels: p.Labels})
-				break
-			}
-		}
-	}
-	sort.Slice(hits, func(i, j int) bool { return hits[i].ID < hits[j].ID })
-	return jsonResult(hits)
+	return x.keywordQuery(userID, stringArg(args, "question"))
 }
 
 func (x *Executor) getClaims(userID string, args map[string]any) (*tools.Result, error) {

--- a/go/memory/executor.go
+++ b/go/memory/executor.go
@@ -380,9 +380,8 @@ func (x *Executor) appendLog(userID, entry string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	_, err = fmt.Fprintf(f, "- [%s] %s\n", time.Now().UTC().Format("2006-01-02 15:04:05"), entry)
-	return err
+	return errors.Join(err, f.Close())
 }
 
 func jsonResult(v any) (*tools.Result, error) {

--- a/go/memory/infer/schema.json
+++ b/go/memory/infer/schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://soypete.tech/pedro-agentware/memory/infer/schema.json",
+  "title": "Wiki-memory Markov link network inference contract",
+  "description": "One contract for both transports (subprocess stdin/stdout today, MCP tool call later). The Go core sends a request built from a user's vault (claim nodes from claims[].id, source nodes from raw/ ids, typed edges); the Python engine (pedro_agentware.memory.infer, pgmpy) replies with per-claim marginals and contested flags. Confidence is written back into claim frontmatter through the enforced write path.",
+  "$defs": {
+    "request": {
+      "type": "object",
+      "required": ["nodes", "edges"],
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "kind"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "kind": { "enum": ["claim", "source"] },
+              "reliability": {
+                "type": "number", "minimum": 0, "maximum": 1,
+                "description": "Source prior override; defaults to weights.sourcePrior, or weights.supersededPrior when superseded."
+              }
+            }
+          }
+        },
+        "edges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["type", "source", "target"],
+            "additionalProperties": false,
+            "properties": {
+              "type": { "enum": ["supports", "contradicts", "sourceOf", "supersedes"] },
+              "source": { "type": "string" },
+              "target": { "type": "string" }
+            }
+          }
+        },
+        "weights": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "supports": { "type": "number", "default": 0.8 },
+            "contradicts": { "type": "number", "default": 0.9 },
+            "sourceOf": { "type": "number", "default": 0.85 },
+            "sourcePrior": { "type": "number", "default": 0.7 },
+            "supersededPrior": { "type": "number", "default": 0.4 },
+            "contestedThreshold": { "type": "number", "default": 0.6 }
+          }
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "required": ["marginals", "contested", "method"],
+      "additionalProperties": false,
+      "properties": {
+        "marginals": {
+          "type": "object",
+          "description": "Per-claim P(true). Source nodes are omitted.",
+          "additionalProperties": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "contested": {
+          "type": "object",
+          "description": "True when the claim has a contradicts edge to a claim whose marginal exceeds contestedThreshold.",
+          "additionalProperties": { "type": "boolean" }
+        },
+        "method": { "enum": ["belief_propagation", "gibbs"] }
+      }
+    },
+    "error": {
+      "type": "object",
+      "required": ["error"],
+      "properties": { "error": { "type": "string" } }
+    }
+  }
+}

--- a/go/memory/lint_test.go
+++ b/go/memory/lint_test.go
@@ -1,0 +1,74 @@
+package memory
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+)
+
+func lintIssues(t *testing.T, w *WikiMemory, args map[string]any) []map[string]any {
+	t.Helper()
+	res, err := w.Execute(callerCtx("alice"), ToolLint, args)
+	if err != nil || !res.Success {
+		t.Fatalf("lint failed: %+v %v", res, err)
+	}
+	var raw []map[string]any
+	if err := json.Unmarshal([]byte(res.Output), &raw); err != nil {
+		t.Fatalf("bad lint output %q: %v", res.Output, err)
+	}
+	return raw
+}
+
+func constraintsByPage(rows []map[string]any) map[string][]string {
+	out := map[string][]string{}
+	for _, row := range rows {
+		page, _ := row["page"].(string)
+		violation := row["Violation"].(map[string]any)
+		out[page] = append(out[page], violation["constraint"].(string))
+	}
+	return out
+}
+
+func TestLintFindsHygieneIssues(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := callerCtx("alice")
+	pages := []string{
+		// Orphan: no links in or out.
+		"---\nid: island-page\ntype: sw:Skill\n---\nNothing links here.\n",
+		// Stale + only bare skos:related links (missing typed links) +
+		// dangling target.
+		"---\nid: old-notes\ntype: sw:Skill\nupdated: 2020-01-01\n---\nSee [[missing-page]].\n",
+		// Healthy: typed link both ways keeps these two non-orphans.
+		"---\nid: goroutines\ntype: sw:Skill\n---\nPart of [[channels|pred=sw:buildsToward]].\n",
+		"---\nid: channels\ntype: sw:Skill\nlinks:\n  - {pred: sw:requiresPrerequisite, target: goroutines}\n---\n",
+	}
+	for _, content := range pages {
+		if res, err := w.Execute(ctx, ToolWritePage, map[string]any{"content": content}); err != nil || !res.Success {
+			t.Fatalf("write failed: %+v %v", res, err)
+		}
+	}
+	got := constraintsByPage(lintIssues(t, w, map[string]any{}))
+
+	assertHas := func(page, constraint string) {
+		t.Helper()
+		if !slices.Contains(got[page], constraint) {
+			t.Errorf("expected %s on %s, got %v", constraint, page, got)
+		}
+	}
+	assertHas("island-page", LintOrphanPage)
+	assertHas("old-notes", LintStalePage)
+	assertHas("old-notes", LintMissingTypedLink)
+	assertHas("old-notes", LintDanglingLink)
+	for _, healthy := range []string{"goroutines", "channels"} {
+		if len(got[healthy]) != 0 {
+			t.Errorf("healthy page %s should be clean, got %v", healthy, got[healthy])
+		}
+	}
+	// stale_days is tunable: with a huge threshold the stale finding goes away.
+	relaxed := constraintsByPage(lintIssues(t, w, map[string]any{"stale_days": float64(36500)}))
+	for _, c := range relaxed["old-notes"] {
+		if c == LintStalePage {
+			t.Errorf("stale finding must respect stale_days, got %v", relaxed["old-notes"])
+		}
+	}
+}

--- a/go/memory/ontology/fixtures_test.go
+++ b/go/memory/ontology/fixtures_test.go
@@ -1,0 +1,123 @@
+package ontology
+
+// Fixture gate for the SKOS validation layer: the loop spec requires these
+// exact behaviors on the thesaurus fixtures before the validator is trusted
+// on real memory content.
+
+import (
+	"context"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/soypete/ontology-go/ttl"
+	"github.com/soypete/ontology-go/types"
+)
+
+const thesaurusDir = "../../../ontologies/thesaurus/"
+
+func loadFixture(t *testing.T, name string) []types.Triple {
+	t.Helper()
+	f, err := os.Open(thesaurusDir + name)
+	if err != nil {
+		t.Skipf("fixture unavailable (run: git submodule update --init): %v", err)
+	}
+	defer f.Close()
+	triples, err := ttl.NewTurtleParser().Parse(f)
+	if err != nil {
+		t.Fatalf("parse %s: %v", name, err)
+	}
+	if len(triples) == 0 {
+		t.Fatalf("fixture %s parsed to zero triples", name)
+	}
+	return triples
+}
+
+func checkGraph(t *testing.T, triples []types.Triple) []Violation {
+	t.Helper()
+	vs, err := CheckSKOSGraph(context.Background(), triples)
+	if err != nil {
+		t.Fatalf("CheckSKOSGraph: %v", err)
+	}
+	return vs
+}
+
+func TestFullSKOSFixturePasses(t *testing.T) {
+	vs := checkGraph(t, loadFixture(t, "full_skos.ttl"))
+	if len(vs) != 0 {
+		t.Errorf("full_skos.ttl must pass, got violations: %v", vs)
+	}
+}
+
+func TestTransitiveBroaderFixturePasses(t *testing.T) {
+	triples := loadFixture(t, "transitive_broader.ttl")
+	if vs := checkGraph(t, triples); len(vs) != 0 {
+		t.Errorf("transitive_broader.ttl must pass, got violations: %v", vs)
+	}
+	// selfPaced → onlineCourse → course must close transitively.
+	closure := TransitiveBroader(triples, "http://example.org/selfPaced")
+	want := []string{"http://example.org/onlineCourse", "http://example.org/course"}
+	for _, iri := range want {
+		if !slices.Contains(closure, iri) {
+			t.Errorf("transitive closure of selfPaced missing %s (got %v)", iri, closure)
+		}
+	}
+}
+
+func TestCycleDetectionFixtureRejected(t *testing.T) {
+	vs := checkGraph(t, loadFixture(t, "cycle_detection.ttl"))
+	var cycles []Violation
+	for _, v := range vs {
+		if v.Constraint == ConstraintSKOSCycle {
+			cycles = append(cycles, v)
+		}
+	}
+	if len(cycles) == 0 {
+		t.Fatalf("cycle_detection.ttl must be rejected with a %s violation, got %v",
+			ConstraintSKOSCycle, vs)
+	}
+	// Diagnostics must be clear: name an offending concept and say "circular".
+	v := cycles[0]
+	if v.Term == "" || v.Message == "" {
+		t.Errorf("cycle violation lacks diagnostics: %+v", v)
+	}
+	// TransitiveBroader must terminate on the cycle (A→B→C→A).
+	closure := TransitiveBroader(loadFixture(t, "cycle_detection.ttl"), "http://example.org/A")
+	if len(closure) != 2 {
+		t.Errorf("cycle closure of A should visit B and C once each, got %v", closure)
+	}
+}
+
+func TestInconsistencyFixtureRejected(t *testing.T) {
+	vs := checkGraph(t, loadFixture(t, "inconsistency_broader_narrower.ttl"))
+	found := false
+	for _, v := range vs {
+		if v.Constraint == ConstraintSKOSHierarchy {
+			found = true
+			if v.Term == "" || v.Message == "" {
+				t.Errorf("inconsistency violation lacks diagnostics: %+v", v)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("inconsistency_broader_narrower.ttl must be rejected with a %s violation, got %v",
+			ConstraintSKOSHierarchy, vs)
+	}
+}
+
+func TestSymmetricRelatedFixtureInference(t *testing.T) {
+	triples := loadFixture(t, "symmetric_related.ttl")
+	inferred := InferSymmetricRelated(triples)
+	want := types.Triple{
+		Subject:   "http://example.org/science",
+		Predicate: "http://www.w3.org/2004/02/skos/core#related",
+		Object:    "http://example.org/math",
+	}
+	if len(inferred) != 1 || inferred[0] != want {
+		t.Fatalf("expected inferred triple %v, got %v", want, inferred)
+	}
+	// Idempotent: once the symmetric closure is present, nothing new.
+	if again := InferSymmetricRelated(append(triples, inferred...)); len(again) != 0 {
+		t.Errorf("inference must be idempotent, got %v", again)
+	}
+}

--- a/go/memory/ontology/fixtures_test.go
+++ b/go/memory/ontology/fixtures_test.go
@@ -22,7 +22,7 @@ func loadFixture(t *testing.T, name string) []types.Triple {
 	if err != nil {
 		t.Skipf("fixture unavailable (run: git submodule update --init): %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	triples, err := ttl.NewTurtleParser().Parse(f)
 	if err != nil {
 		t.Fatalf("parse %s: %v", name, err)

--- a/go/memory/ontology/tbox.go
+++ b/go/memory/ontology/tbox.go
@@ -1,0 +1,234 @@
+// Package ontology loads a read-only T-box and validates wiki-memory
+// content against it. It is the single source of validation rules with two
+// consumers: the middleware OntologyEvaluator (write-time enforcement) and
+// the memlint CI check. Gaps in the T-box are recorded in SCHEMA_GAPS.md,
+// never patched here.
+package ontology
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/soypete/ontology-go/ttl"
+	"github.com/soypete/ontology-go/types"
+)
+
+const (
+	owlClass       = "http://www.w3.org/2002/07/owl#Class"
+	rdfsClass      = types.RDFSNamespace + "Class"
+	skosNS         = "http://www.w3.org/2004/02/skos/core#"
+	skosConcept    = skosNS + "Concept"
+	skosPrefLabel  = skosNS + "prefLabel"
+	skosAltLabel   = skosNS + "altLabel"
+	skosRelated    = skosNS + "related"
+	skosBroader    = skosNS + "broader"
+	skosNarrower   = skosNS + "narrower"
+	dctermsSubject = "http://purl.org/dc/terms/subject"
+	rdfsLabel      = types.RDFSLabel
+)
+
+// Property is a T-box property with its declared domains and ranges.
+type Property struct {
+	IRI    string
+	Domain []string
+	Range  []string
+}
+
+// TBox is an indexed, read-only terminology: classes, properties with
+// domain/range, SKOS concepts, and labels for suggestions and ingest-time
+// label matching.
+type TBox struct {
+	classes    map[string]bool
+	properties map[string]*Property
+	concepts   map[string]bool
+	superOf    map[string][]string
+	labelIndex map[string]string // lowercased pref/alt label -> concept IRI
+	triples    []types.Triple
+}
+
+// Load parses the given Turtle files and builds a merged T-box index.
+func Load(paths ...string) (*TBox, error) {
+	var all []types.Triple
+	for _, path := range paths {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("ontology: open %s: %w", path, err)
+		}
+		triples, err := ttl.NewTurtleParser().Parse(f)
+		f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("ontology: parse %s: %w", path, err)
+		}
+		all = append(all, triples...)
+	}
+	return New(all), nil
+}
+
+// New builds a T-box index from already-parsed triples.
+func New(triples []types.Triple) *TBox {
+	t := &TBox{
+		classes:    make(map[string]bool),
+		properties: make(map[string]*Property),
+		concepts:   make(map[string]bool),
+		superOf:    make(map[string][]string),
+		labelIndex: make(map[string]string),
+		triples:    triples,
+	}
+	// SKOS core properties and the topic predicate are usable without being
+	// re-declared in the T-box (standard vocabulary, not invented terms).
+	for _, iri := range []string{skosRelated, skosBroader, skosNarrower, dctermsSubject} {
+		t.properties[iri] = &Property{IRI: iri}
+	}
+	prop := func(subj string) *Property {
+		if t.properties[subj] == nil {
+			t.properties[subj] = &Property{IRI: subj}
+		}
+		return t.properties[subj]
+	}
+	for _, tr := range triples {
+		switch tr.Predicate {
+		case types.RDFType:
+			switch tr.Object {
+			case owlClass, rdfsClass:
+				t.classes[tr.Subject] = true
+			case skosConcept:
+				t.concepts[tr.Subject] = true
+			case types.OWLObjectProperty, types.OWLDatatypeProperty,
+				types.OWLAnnotationProperty, types.RDFNS + "Property":
+				prop(tr.Subject)
+			}
+		case types.RDFSSubClassOf:
+			t.superOf[tr.Subject] = append(t.superOf[tr.Subject], tr.Object)
+		case types.RDFSdomain:
+			p := prop(tr.Subject)
+			p.Domain = append(p.Domain, tr.Object)
+		case types.RDFSRange:
+			p := prop(tr.Subject)
+			p.Range = append(p.Range, tr.Object)
+		case skosPrefLabel, skosAltLabel, rdfsLabel:
+			if tr.IsLiteral {
+				t.labelIndex[strings.ToLower(tr.Object)] = tr.Subject
+			}
+		}
+	}
+	return t
+}
+
+// Triples returns the raw T-box triples (read-only; callers must not modify).
+func (t *TBox) Triples() []types.Triple { return t.triples }
+
+// HasClass reports whether iri is a declared class.
+func (t *TBox) HasClass(iri string) bool { return t.classes[iri] }
+
+// HasConcept reports whether iri is a declared SKOS concept.
+func (t *TBox) HasConcept(iri string) bool { return t.concepts[iri] }
+
+// PropertyFor returns the property declaration for iri, if any.
+func (t *TBox) PropertyFor(iri string) (*Property, bool) {
+	p, ok := t.properties[iri]
+	return p, ok
+}
+
+// IsSubclassOf reports whether class equals ancestor or reaches it via
+// rdfs:subClassOf (transitive).
+func (t *TBox) IsSubclassOf(class, ancestor string) bool {
+	if class == ancestor {
+		return true
+	}
+	seen := map[string]bool{class: true}
+	queue := append([]string{}, t.superOf[class]...)
+	for len(queue) > 0 {
+		c := queue[0]
+		queue = queue[1:]
+		if c == ancestor {
+			return true
+		}
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		queue = append(queue, t.superOf[c]...)
+	}
+	return false
+}
+
+// MatchConceptLabel resolves a human label ("Golang") to a concept IRI via
+// case-insensitive prefLabel/altLabel matching. Used during ingest.
+func (t *TBox) MatchConceptLabel(label string) (string, bool) {
+	iri, ok := t.labelIndex[strings.ToLower(strings.TrimSpace(label))]
+	return iri, ok
+}
+
+// TermKind selects which vocabulary Nearest searches.
+type TermKind int
+
+const (
+	KindClass TermKind = iota
+	KindProperty
+	KindConcept
+)
+
+// Nearest returns up to n known terms of the given kind closest to iri by
+// edit distance over local names. Used to build self-correction diagnostics.
+func (t *TBox) Nearest(iri string, kind TermKind, n int) []string {
+	var pool []string
+	switch kind {
+	case KindClass:
+		for c := range t.classes {
+			pool = append(pool, c)
+		}
+	case KindProperty:
+		for p := range t.properties {
+			pool = append(pool, p)
+		}
+	case KindConcept:
+		for c := range t.concepts {
+			pool = append(pool, c)
+		}
+	}
+	target := strings.ToLower(localName(iri))
+	sort.Slice(pool, func(i, j int) bool {
+		di := levenshtein(target, strings.ToLower(localName(pool[i])))
+		dj := levenshtein(target, strings.ToLower(localName(pool[j])))
+		if di != dj {
+			return di < dj
+		}
+		return pool[i] < pool[j]
+	})
+	if len(pool) > n {
+		pool = pool[:n]
+	}
+	return pool
+}
+
+func localName(iri string) string {
+	for _, sep := range []string{"#", "/"} {
+		if i := strings.LastIndex(iri, sep); i >= 0 && i < len(iri)-1 {
+			return iri[i+1:]
+		}
+	}
+	return iri
+}
+
+func levenshtein(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	prev := make([]int, len(rb)+1)
+	cur := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		cur[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			cur[j] = min(prev[j]+1, min(cur[j-1]+1, prev[j-1]+cost))
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(rb)]
+}

--- a/go/memory/ontology/tbox.go
+++ b/go/memory/ontology/tbox.go
@@ -57,7 +57,7 @@ func Load(paths ...string) (*TBox, error) {
 			return nil, fmt.Errorf("ontology: open %s: %w", path, err)
 		}
 		triples, err := ttl.NewTurtleParser().Parse(f)
-		f.Close()
+		_ = f.Close() // read-only handle; a parse error takes precedence
 		if err != nil {
 			return nil, fmt.Errorf("ontology: parse %s: %w", path, err)
 		}

--- a/go/memory/ontology/tbox_test.go
+++ b/go/memory/ontology/tbox_test.go
@@ -1,0 +1,196 @@
+package ontology
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/soypete/pedro-agentware/go/memory/page"
+)
+
+const (
+	tboxEducation = "../../../ontologies/education/TBOX_LEARNING_SOFTWARE.ttl"
+	tboxTopics    = "../../../ontologies/social/twitch_topics.ttl"
+	l2ws          = "http://soypete.tech/l2ws/"
+	twitch        = "http://soypete.tech/twitch/topics/"
+)
+
+func loadTBox(t *testing.T) *TBox {
+	t.Helper()
+	paths := []string{tboxEducation, tboxTopics}
+	for _, p := range paths {
+		if _, err := filepath.Abs(p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tb, err := Load(paths...)
+	if err != nil {
+		t.Skipf("T-box fixtures unavailable (run: git submodule update --init): %v", err)
+	}
+	return tb
+}
+
+func TestLoadIndexesRealTBox(t *testing.T) {
+	tb := loadTBox(t)
+	for _, class := range []string{l2ws + "Skill", l2ws + "Beginner", l2ws + "Course"} {
+		if !tb.HasClass(class) {
+			t.Errorf("expected class %s", class)
+		}
+	}
+	if tb.HasClass(l2ws + "NotAClass") {
+		t.Error("NotAClass should not be a class")
+	}
+	prop, ok := tb.PropertyFor(l2ws + "requiresPrerequisite")
+	if !ok {
+		t.Fatal("expected property requiresPrerequisite")
+	}
+	if len(prop.Domain) == 0 || prop.Domain[0] != l2ws+"Skill" {
+		t.Errorf("requiresPrerequisite domain: %v", prop.Domain)
+	}
+	if !tb.HasConcept(twitch + "Go") {
+		t.Error("expected twitch:Go concept")
+	}
+	// skos core properties are built in without T-box declarations.
+	if _, ok := tb.PropertyFor("http://www.w3.org/2004/02/skos/core#related"); !ok {
+		t.Error("expected built-in skos:related")
+	}
+}
+
+func TestMatchConceptLabel(t *testing.T) {
+	tb := loadTBox(t)
+	iri, ok := tb.MatchConceptLabel("Golang")
+	if !ok || iri != twitch+"Go" {
+		t.Errorf("MatchConceptLabel(Golang) = %q, %v; want twitch:Go", iri, ok)
+	}
+	if _, ok := tb.MatchConceptLabel("definitely-not-a-topic"); ok {
+		t.Error("unexpected match for unknown label")
+	}
+}
+
+func TestNearestSuggestsSimilarTerms(t *testing.T) {
+	tb := loadTBox(t)
+	nearest := tb.Nearest(l2ws+"Skil", KindClass, 3)
+	if len(nearest) == 0 || nearest[0] != l2ws+"Skill" {
+		t.Errorf("Nearest(Skil) = %v; want sw:Skill first", nearest)
+	}
+}
+
+func TestIsSubclassOfTransitive(t *testing.T) {
+	tb := loadTBox(t)
+	// sw:Syntax rdfs:subClassOf sw:Fundamentals in the T-box.
+	if !tb.IsSubclassOf(l2ws+"Syntax", l2ws+"Fundamentals") {
+		t.Error("Syntax should be a subclass of Fundamentals")
+	}
+	if !tb.IsSubclassOf(l2ws+"Skill", l2ws+"Skill") {
+		t.Error("IsSubclassOf should be reflexive")
+	}
+	if tb.IsSubclassOf(l2ws+"Skill", l2ws+"Course") {
+		t.Error("Skill is not a subclass of Course")
+	}
+}
+
+func mustParse(t *testing.T, src string) *page.Page {
+	t.Helper()
+	p, err := page.Parse([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const validPage = `---
+id: go-worker-pools
+type: sw:Skill
+labels: ["Worker Pools"]
+topics: [twitch:Go]
+links:
+  - {pred: sw:requiresPrerequisite, target: goroutines}
+---
+Body with [[channels]].
+`
+
+func TestValidatePageAccepts(t *testing.T) {
+	tb := loadTBox(t)
+	p := mustParse(t, validPage)
+	resolve := func(id string) (string, bool) {
+		if id == "goroutines" || id == "channels" {
+			return "sw:Skill", true
+		}
+		return "", false
+	}
+	if vs := tb.ValidatePage(p, resolve, nil); len(vs) != 0 {
+		t.Errorf("expected clean page, got %v", vs)
+	}
+}
+
+func TestValidatePageUnknownClassGetsNearest(t *testing.T) {
+	tb := loadTBox(t)
+	p := mustParse(t, "---\nid: x-page\ntype: sw:Skil\n---\n")
+	vs := tb.ValidatePage(p, nil, nil)
+	if len(vs) != 1 || vs[0].Constraint != ConstraintUnknownClass {
+		t.Fatalf("expected one unknown-class violation, got %v", vs)
+	}
+	if len(vs[0].Nearest) == 0 || vs[0].Nearest[0] != l2ws+"Skill" {
+		t.Errorf("expected sw:Skill as nearest term, got %v", vs[0].Nearest)
+	}
+}
+
+func TestValidatePageUnknownTopicAndProperty(t *testing.T) {
+	tb := loadTBox(t)
+	src := `---
+id: x-page
+type: sw:Skill
+topics: [twitch:Golangg]
+links:
+  - {pred: sw:requiresPrereq, target: other-page}
+---
+`
+	vs := tb.ValidatePage(mustParse(t, src), nil, nil)
+	got := map[string]bool{}
+	for _, v := range vs {
+		got[v.Constraint] = true
+		if len(v.Nearest) == 0 {
+			t.Errorf("%s: expected nearest-term suggestions", v.Constraint)
+		}
+	}
+	if !got[ConstraintUnknownConcept] || !got[ConstraintUnknownProperty] {
+		t.Errorf("expected unknown-concept and unknown-property, got %v", vs)
+	}
+}
+
+func TestValidatePageDomainAndRange(t *testing.T) {
+	tb := loadTBox(t)
+	// requiresPrerequisite has domain sw:Skill; a Course page using it
+	// violates the domain. Its range is sw:Skill; a Role target violates it.
+	src := `---
+id: x-page
+type: sw:Course
+links:
+  - {pred: sw:requiresPrerequisite, target: some-role}
+---
+`
+	resolve := func(id string) (string, bool) { return "sw:Role", true }
+	vs := tb.ValidatePage(mustParse(t, src), resolve, nil)
+	got := map[string]bool{}
+	for _, v := range vs {
+		got[v.Constraint] = true
+	}
+	if !got[ConstraintDomain] || !got[ConstraintRange] {
+		t.Errorf("expected domain and range violations, got %v", vs)
+	}
+	// Unresolvable target: range check is skipped, domain still fails.
+	vs = tb.ValidatePage(mustParse(t, src), func(string) (string, bool) { return "", false }, nil)
+	for _, v := range vs {
+		if v.Constraint == ConstraintRange {
+			t.Errorf("range must be skipped for dangling targets, got %v", vs)
+		}
+	}
+}
+
+func TestValidatePageUnknownPrefix(t *testing.T) {
+	tb := loadTBox(t)
+	p := mustParse(t, "---\nid: x-page\ntype: bogus:Thing\n---\n")
+	vs := tb.ValidatePage(p, nil, nil)
+	if len(vs) != 1 || vs[0].Constraint != ConstraintUnknownPrefix {
+		t.Errorf("expected unknown-prefix violation, got %v", vs)
+	}
+}

--- a/go/memory/ontology/validate.go
+++ b/go/memory/ontology/validate.go
@@ -185,6 +185,32 @@ func CheckSKOSGraph(ctx context.Context, triples []types.Triple) ([]Violation, e
 // ErrNoTriples reports an empty graph passed to inference helpers.
 var ErrNoTriples = errors.New("ontology: no triples")
 
+// TransitiveBroader returns every concept reachable from subject via
+// skos:broader (the skos:broaderTransitive closure), in BFS order. Cycles
+// are tolerated: each node is visited once.
+func TransitiveBroader(triples []types.Triple, subject string) []string {
+	broader := make(map[string][]string)
+	for _, t := range triples {
+		if t.Predicate == skosBroader {
+			broader[t.Subject] = append(broader[t.Subject], t.Object)
+		}
+	}
+	seen := map[string]bool{subject: true}
+	var out []string
+	queue := append([]string{}, broader[subject]...)
+	for len(queue) > 0 {
+		c := queue[0]
+		queue = queue[1:]
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+		queue = append(queue, broader[c]...)
+	}
+	return out
+}
+
 // InferSymmetricRelated returns the skos:related triples implied by symmetry
 // (a related b ⇒ b related a) that are not already present.
 func InferSymmetricRelated(triples []types.Triple) []types.Triple {

--- a/go/memory/ontology/validate.go
+++ b/go/memory/ontology/validate.go
@@ -1,0 +1,210 @@
+package ontology
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/soypete/ontology-go/types"
+	"github.com/soypete/ontology-go/validate"
+
+	"github.com/soypete/pedro-agentware/go/memory/page"
+)
+
+// Constraint identifiers carried in Violation.Constraint. Stable strings:
+// they are part of the DENY diagnostic contract agents self-correct against.
+const (
+	ConstraintUnknownPrefix   = "unknown-prefix"
+	ConstraintUnknownClass    = "unknown-class"
+	ConstraintUnknownProperty = "unknown-property"
+	ConstraintUnknownConcept  = "unknown-concept"
+	ConstraintDomain          = "domain-mismatch"
+	ConstraintRange           = "range-mismatch"
+	ConstraintSKOSCycle       = "skos-cycle"
+	ConstraintSKOSHierarchy   = "skos-inconsistent-hierarchy"
+)
+
+// Violation is a structured diagnostic for one constraint failure. DENY
+// decisions carry these so the calling agent can correct the page and retry.
+type Violation struct {
+	Constraint string   `json:"constraint"`
+	Term       string   `json:"term"`
+	Message    string   `json:"message"`
+	Nearest    []string `json:"nearest,omitempty"`
+}
+
+func (v Violation) String() string {
+	s := fmt.Sprintf("%s: %s (%s)", v.Constraint, v.Term, v.Message)
+	if len(v.Nearest) > 0 {
+		s += fmt.Sprintf(" — nearest valid terms: %v", v.Nearest)
+	}
+	return s
+}
+
+// TypeResolver reports the type CURIE of an existing page in the same vault,
+// used for link range checks. Returning ok=false means the target page does
+// not exist yet; range checks are skipped for it (wikis grow incrementally —
+// memory_lint reports dangling links later).
+type TypeResolver func(pageID string) (typeCURIE string, ok bool)
+
+// ValidatePage checks a parsed page against the T-box: type class exists,
+// topics are known concepts, link predicates exist and respect domain/range.
+// A nil resolver skips all range checks.
+func (t *TBox) ValidatePage(p *page.Page, resolve TypeResolver, prefixes map[string]string) []Violation {
+	if prefixes == nil {
+		prefixes = page.DefaultPrefixes()
+	}
+	var vs []Violation
+
+	expand := func(curie string) (string, bool) {
+		iri, err := page.ExpandCURIE(curie, prefixes)
+		if err != nil {
+			vs = append(vs, Violation{
+				Constraint: ConstraintUnknownPrefix,
+				Term:       curie,
+				Message:    err.Error(),
+			})
+			return "", false
+		}
+		return iri, true
+	}
+
+	pageType, typeOK := "", false
+	if iri, ok := expand(p.Type); ok {
+		pageType = iri
+		if !t.HasClass(iri) {
+			vs = append(vs, Violation{
+				Constraint: ConstraintUnknownClass,
+				Term:       p.Type,
+				Message:    fmt.Sprintf("type %q is not a class in the T-box", iri),
+				Nearest:    t.Nearest(iri, KindClass, 3),
+			})
+		} else {
+			typeOK = true
+		}
+	}
+
+	for _, topic := range p.Topics {
+		iri, ok := expand(topic)
+		if !ok {
+			continue
+		}
+		if !t.HasConcept(iri) {
+			vs = append(vs, Violation{
+				Constraint: ConstraintUnknownConcept,
+				Term:       topic,
+				Message:    fmt.Sprintf("topic %q is not a skos:Concept in the T-box", iri),
+				Nearest:    t.Nearest(iri, KindConcept, 3),
+			})
+		}
+	}
+
+	for _, link := range p.AllLinks() {
+		predIRI, ok := expand(link.Pred)
+		if !ok {
+			continue
+		}
+		prop, known := t.PropertyFor(predIRI)
+		if !known {
+			vs = append(vs, Violation{
+				Constraint: ConstraintUnknownProperty,
+				Term:       link.Pred,
+				Message:    fmt.Sprintf("predicate %q is not a property in the T-box", predIRI),
+				Nearest:    t.Nearest(predIRI, KindProperty, 3),
+			})
+			continue
+		}
+		if typeOK && len(prop.Domain) > 0 && !t.subclassOfAny(pageType, prop.Domain) {
+			vs = append(vs, Violation{
+				Constraint: ConstraintDomain,
+				Term:       link.Pred,
+				Message: fmt.Sprintf("page type %s is outside the domain of %s (domain: %v)",
+					p.Type, link.Pred, prop.Domain),
+			})
+		}
+		if resolve == nil || len(prop.Range) == 0 {
+			continue
+		}
+		targetCURIE, exists := resolve(link.Target)
+		if !exists {
+			continue
+		}
+		targetIRI, ok := expand(targetCURIE)
+		if !ok {
+			continue
+		}
+		if !t.subclassOfAny(targetIRI, prop.Range) {
+			vs = append(vs, Violation{
+				Constraint: ConstraintRange,
+				Term:       link.Pred,
+				Message: fmt.Sprintf("link target %q has type %s, outside the range of %s (range: %v)",
+					link.Target, targetCURIE, link.Pred, prop.Range),
+			})
+		}
+	}
+	return vs
+}
+
+func (t *TBox) subclassOfAny(class string, ancestors []string) bool {
+	for _, a := range ancestors {
+		if t.IsSubclassOf(class, a) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckSKOSGraph runs the SKOS structural checks (broader cycles,
+// broader/narrower hierarchy inconsistency) over a triple set — typically a
+// vault's merged A-box, optionally combined with T-box concept triples.
+func CheckSKOSGraph(ctx context.Context, triples []types.Triple) ([]Violation, error) {
+	report, err := validate.NewValidator(triples).Validate(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ontology: skos validation: %w", err)
+	}
+	var vs []Violation
+	for _, issue := range report.Issues {
+		switch issue.Type {
+		case validate.IssueCircularBroader:
+			vs = append(vs, Violation{
+				Constraint: ConstraintSKOSCycle,
+				Term:       issue.Subject,
+				Message:    issue.Message,
+			})
+		case validate.IssueInconsistentHierarchy:
+			vs = append(vs, Violation{
+				Constraint: ConstraintSKOSHierarchy,
+				Term:       issue.Subject,
+				Message:    issue.Message,
+			})
+		}
+	}
+	return vs, nil
+}
+
+// ErrNoTriples reports an empty graph passed to inference helpers.
+var ErrNoTriples = errors.New("ontology: no triples")
+
+// InferSymmetricRelated returns the skos:related triples implied by symmetry
+// (a related b ⇒ b related a) that are not already present.
+func InferSymmetricRelated(triples []types.Triple) []types.Triple {
+	present := make(map[[2]string]bool)
+	for _, t := range triples {
+		if t.Predicate == skosRelated {
+			present[[2]string{t.Subject, t.Object}] = true
+		}
+	}
+	var inferred []types.Triple
+	for pair := range present {
+		inverse := [2]string{pair[1], pair[0]}
+		if !present[inverse] {
+			inferred = append(inferred, types.Triple{
+				Subject:   pair[1],
+				Predicate: skosRelated,
+				Object:    pair[0],
+			})
+			present[inverse] = true
+		}
+	}
+	return inferred
+}

--- a/go/memory/page/page.go
+++ b/go/memory/page/page.go
@@ -31,13 +31,17 @@ type Link struct {
 	Target string `yaml:"target"`
 }
 
-// Claim is an atomic assertion tracked by the inference layer.
+// Claim is an atomic assertion tracked by the inference layer. Supports
+// and Contradicts reference other claims: "c2" within the same page or
+// "other-page#c1" across pages.
 type Claim struct {
-	ID         string   `yaml:"id"`
-	Text       string   `yaml:"text"`
-	Sources    []string `yaml:"sources"`
-	Confidence *float64 `yaml:"confidence"`
-	Contested  bool     `yaml:"contested"`
+	ID          string   `yaml:"id"`
+	Text        string   `yaml:"text"`
+	Sources     []string `yaml:"sources"`
+	Supports    []string `yaml:"supports"`
+	Contradicts []string `yaml:"contradicts"`
+	Confidence  *float64 `yaml:"confidence"`
+	Contested   bool     `yaml:"contested"`
 }
 
 // Frontmatter is the typed header of a wiki page (see SCHEMA.md).
@@ -81,6 +85,7 @@ var (
 	pageIDPattern    = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 	curiePattern     = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*:[A-Za-z0-9_-]+$`)
 	wikilinkPattern  = regexp.MustCompile(`\[\[([a-z0-9-]+)(?:\|pred=([A-Za-z][A-Za-z0-9]*:[A-Za-z0-9_-]+))?\]\]`)
+	claimRefPattern  = regexp.MustCompile(`^([a-z0-9]+(-[a-z0-9]+)*#)?[A-Za-z0-9_-]+$`)
 )
 
 // Parse parses raw page bytes. It enforces the structural contract (required
@@ -141,6 +146,11 @@ func (p *Page) checkContract() error {
 			return fmt.Errorf("%w: duplicate claim id %q", ErrContract, c.ID)
 		}
 		claimIDs[c.ID] = true
+		for _, ref := range append(append([]string{}, c.Supports...), c.Contradicts...) {
+			if !claimRefPattern.MatchString(ref) {
+				return fmt.Errorf("%w: claim ref %q (want \"c2\" or \"page-id#c2\")", ErrContract, ref)
+			}
+		}
 	}
 	return nil
 }

--- a/go/memory/page/page.go
+++ b/go/memory/page/page.go
@@ -1,0 +1,161 @@
+// Package page parses wiki-memory pages: YAML frontmatter per the contract
+// in SCHEMA.md plus typed wikilinks in prose, and emits the page's A-box as
+// N-Triples for validation against the T-box.
+package page
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultLinkPred is the predicate assumed for bare [[target]] wikilinks.
+const DefaultLinkPred = "skos:related"
+
+var (
+	// ErrNoFrontmatter reports a page without a leading YAML frontmatter block.
+	ErrNoFrontmatter = errors.New("page: missing frontmatter block")
+	// ErrContract reports frontmatter that violates the structural contract
+	// (missing/invalid id or type). Semantic (ontology) violations are the
+	// validator's job, not the parser's.
+	ErrContract = errors.New("page: frontmatter contract violation")
+)
+
+// Link is a typed edge to another page in the same vault.
+type Link struct {
+	Pred   string `yaml:"pred"`
+	Target string `yaml:"target"`
+}
+
+// Claim is an atomic assertion tracked by the inference layer.
+type Claim struct {
+	ID         string   `yaml:"id"`
+	Text       string   `yaml:"text"`
+	Sources    []string `yaml:"sources"`
+	Confidence *float64 `yaml:"confidence"`
+	Contested  bool     `yaml:"contested"`
+}
+
+// Frontmatter is the typed header of a wiki page (see SCHEMA.md).
+type Frontmatter struct {
+	ID      string   `yaml:"id"`
+	Type    string   `yaml:"type"`
+	Labels  []string `yaml:"labels"`
+	Topics  []string `yaml:"topics"`
+	Links   []Link   `yaml:"links"`
+	Claims  []Claim  `yaml:"claims"`
+	Sources []string `yaml:"sources"`
+	Updated string   `yaml:"updated"`
+}
+
+// Page is a parsed wiki page.
+type Page struct {
+	Frontmatter
+	// Body is the markdown after the frontmatter block.
+	Body string
+	// ProseLinks are wikilinks extracted from Body: [[target|pred=p]] typed,
+	// [[target]] defaulting to skos:related.
+	ProseLinks []Link
+}
+
+// AllLinks returns frontmatter links followed by prose links, deduplicated
+// by (pred, target).
+func (p *Page) AllLinks() []Link {
+	seen := make(map[Link]bool)
+	var out []Link
+	for _, l := range append(append([]Link{}, p.Links...), p.ProseLinks...) {
+		if !seen[l] {
+			seen[l] = true
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+var (
+	frontmatterDelim = []byte("---")
+	pageIDPattern    = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	curiePattern     = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*:[A-Za-z0-9_-]+$`)
+	wikilinkPattern  = regexp.MustCompile(`\[\[([a-z0-9-]+)(?:\|pred=([A-Za-z][A-Za-z0-9]*:[A-Za-z0-9_-]+))?\]\]`)
+)
+
+// Parse parses raw page bytes. It enforces the structural contract (required
+// kebab-case id, required CURIE type, kebab-case link targets, CURIE link
+// predicates, unique claim ids); ontology-level validity is checked later by
+// the validator.
+func Parse(data []byte) (*Page, error) {
+	fm, body, err := splitFrontmatter(data)
+	if err != nil {
+		return nil, err
+	}
+	var p Page
+	dec := yaml.NewDecoder(bytes.NewReader(fm))
+	dec.KnownFields(true)
+	if err := dec.Decode(&p.Frontmatter); err != nil {
+		return nil, fmt.Errorf("page: parse frontmatter: %w", err)
+	}
+	p.Body = string(body)
+	for _, m := range wikilinkPattern.FindAllStringSubmatch(p.Body, -1) {
+		link := Link{Pred: m[2], Target: m[1]}
+		if link.Pred == "" {
+			link.Pred = DefaultLinkPred
+		}
+		p.ProseLinks = append(p.ProseLinks, link)
+	}
+	if err := p.checkContract(); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (p *Page) checkContract() error {
+	if !pageIDPattern.MatchString(p.ID) {
+		return fmt.Errorf("%w: id %q is not kebab-case", ErrContract, p.ID)
+	}
+	if !curiePattern.MatchString(p.Type) {
+		return fmt.Errorf("%w: type %q is not a CURIE", ErrContract, p.Type)
+	}
+	for _, t := range p.Topics {
+		if !curiePattern.MatchString(t) {
+			return fmt.Errorf("%w: topic %q is not a CURIE", ErrContract, t)
+		}
+	}
+	for _, l := range p.Links {
+		if !curiePattern.MatchString(l.Pred) {
+			return fmt.Errorf("%w: link pred %q is not a CURIE", ErrContract, l.Pred)
+		}
+		if !pageIDPattern.MatchString(l.Target) {
+			return fmt.Errorf("%w: link target %q is not a kebab-case page id", ErrContract, l.Target)
+		}
+	}
+	claimIDs := make(map[string]bool)
+	for _, c := range p.Claims {
+		if c.ID == "" || strings.TrimSpace(c.Text) == "" {
+			return fmt.Errorf("%w: claim needs non-empty id and text", ErrContract)
+		}
+		if claimIDs[c.ID] {
+			return fmt.Errorf("%w: duplicate claim id %q", ErrContract, c.ID)
+		}
+		claimIDs[c.ID] = true
+	}
+	return nil
+}
+
+// splitFrontmatter returns the YAML block between the first two `---` lines
+// and the remaining body.
+func splitFrontmatter(data []byte) (fm, body []byte, err error) {
+	lines := bytes.SplitAfter(data, []byte("\n"))
+	if len(lines) == 0 || !bytes.Equal(bytes.TrimSpace(lines[0]), frontmatterDelim) {
+		return nil, nil, ErrNoFrontmatter
+	}
+	for i := 1; i < len(lines); i++ {
+		if bytes.Equal(bytes.TrimSpace(lines[i]), frontmatterDelim) {
+			return bytes.Join(lines[1:i], nil), bytes.Join(lines[i+1:], nil), nil
+		}
+	}
+	return nil, nil, fmt.Errorf("%w: unterminated block", ErrNoFrontmatter)
+}

--- a/go/memory/page/page_test.go
+++ b/go/memory/page/page_test.go
@@ -1,0 +1,132 @@
+package page
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const samplePage = `---
+id: go-worker-pools
+type: sw:Skill
+labels: ["Worker Pools", "worker pool pattern"]
+topics: [twitch:Go, twitch:Concurrency]
+links:
+  - {pred: sw:requiresPrerequisite, target: goroutines}
+  - {pred: skos:related, target: channels}
+claims:
+  - {id: c1, text: "Bounded worker pools prevent goroutine leaks under load",
+     sources: [src-pprof-talk], confidence: null}
+sources: [src-pprof-talk, src-go-blog-pipelines]
+updated: 2026-07-30
+---
+
+Worker pools bound concurrency. They build on [[goroutines]] and
+[[select-statement|pred=sw:requiresPrerequisite]]; mastering them
+[[go-concurrency-expert|pred=sw:buildsToward]].
+`
+
+func TestParseSamplePage(t *testing.T) {
+	p, err := Parse([]byte(samplePage))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if p.ID != "go-worker-pools" || p.Type != "sw:Skill" {
+		t.Errorf("frontmatter mismatch: id=%q type=%q", p.ID, p.Type)
+	}
+	if len(p.Labels) != 2 || p.Labels[0] != "Worker Pools" {
+		t.Errorf("labels mismatch: %v", p.Labels)
+	}
+	if len(p.Claims) != 1 || p.Claims[0].ID != "c1" || p.Claims[0].Confidence != nil {
+		t.Errorf("claims mismatch: %+v", p.Claims)
+	}
+	wantProse := []Link{
+		{Pred: "skos:related", Target: "goroutines"},
+		{Pred: "sw:requiresPrerequisite", Target: "select-statement"},
+		{Pred: "sw:buildsToward", Target: "go-concurrency-expert"},
+	}
+	if len(p.ProseLinks) != len(wantProse) {
+		t.Fatalf("prose links: got %v want %v", p.ProseLinks, wantProse)
+	}
+	for i, want := range wantProse {
+		if p.ProseLinks[i] != want {
+			t.Errorf("prose link %d: got %v want %v", i, p.ProseLinks[i], want)
+		}
+	}
+	// AllLinks dedupes: frontmatter has 2, prose has 3, one overlap
+	// (goroutines via skos:related is distinct from sw:requiresPrerequisite).
+	all := p.AllLinks()
+	if len(all) != 5 {
+		t.Errorf("AllLinks: got %d links %v, want 5", len(all), all)
+	}
+}
+
+func TestParseContractViolations(t *testing.T) {
+	cases := map[string]string{
+		"no frontmatter":     "just prose\n",
+		"unterminated":       "---\nid: x\n",
+		"missing id":         "---\ntype: sw:Skill\n---\n",
+		"bad id case":        "---\nid: BadID\ntype: sw:Skill\n---\n",
+		"missing type":       "---\nid: ok-page\n---\n",
+		"type not curie":     "---\nid: ok-page\ntype: Skill\n---\n",
+		"topic not curie":    "---\nid: ok-page\ntype: sw:Skill\ntopics: [NotCurie]\n---\n",
+		"bad link target":    "---\nid: ok-page\ntype: sw:Skill\nlinks:\n  - {pred: skos:related, target: \"../evil\"}\n---\n",
+		"bad link pred":      "---\nid: ok-page\ntype: sw:Skill\nlinks:\n  - {pred: related, target: other-page}\n---\n",
+		"duplicate claim id": "---\nid: ok-page\ntype: sw:Skill\nclaims:\n  - {id: c1, text: a}\n  - {id: c1, text: b}\n---\n",
+		"empty claim text":   "---\nid: ok-page\ntype: sw:Skill\nclaims:\n  - {id: c1, text: \"  \"}\n---\n",
+		"unknown field":      "---\nid: ok-page\ntype: sw:Skill\nbogus: field\n---\n",
+	}
+	for name, src := range cases {
+		if _, err := Parse([]byte(src)); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+}
+
+func TestParseErrorKinds(t *testing.T) {
+	if _, err := Parse([]byte("plain\n")); !errors.Is(err, ErrNoFrontmatter) {
+		t.Errorf("expected ErrNoFrontmatter, got %v", err)
+	}
+	if _, err := Parse([]byte("---\nid: Bad_ID\ntype: sw:Skill\n---\n")); !errors.Is(err, ErrContract) {
+		t.Errorf("expected ErrContract, got %v", err)
+	}
+}
+
+func TestTriplesEmitsABox(t *testing.T) {
+	p, err := Parse([]byte(samplePage))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sb strings.Builder
+	if err := p.WriteNTriples(&sb, DefaultBase+"alice/", nil); err != nil {
+		t.Fatalf("WriteNTriples: %v", err)
+	}
+	nt := sb.String()
+	want := []string{
+		`<http://soypete.tech/memory/alice/go-worker-pools> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://soypete.tech/l2ws/Skill> .`,
+		`<http://soypete.tech/memory/alice/go-worker-pools> <http://www.w3.org/2004/02/skos/core#prefLabel> "Worker Pools" .`,
+		`<http://soypete.tech/memory/alice/go-worker-pools> <http://www.w3.org/2004/02/skos/core#altLabel> "worker pool pattern" .`,
+		`<http://soypete.tech/memory/alice/go-worker-pools> <http://purl.org/dc/terms/subject> <http://soypete.tech/twitch/topics/Go> .`,
+		`<http://soypete.tech/memory/alice/go-worker-pools> <http://soypete.tech/l2ws/requiresPrerequisite> <http://soypete.tech/memory/alice/goroutines> .`,
+		`<http://soypete.tech/memory/alice/go-worker-pools> <http://soypete.tech/l2ws/buildsToward> <http://soypete.tech/memory/alice/go-concurrency-expert> .`,
+	}
+	for _, line := range want {
+		if !strings.Contains(nt, line) {
+			t.Errorf("missing triple:\n%s\nin output:\n%s", line, nt)
+		}
+	}
+	if got := strings.Count(nt, "\n"); got != 10 {
+		t.Errorf("expected 10 triples (1 type + 2 labels + 2 topics + 5 links), got %d:\n%s", got, nt)
+	}
+}
+
+func TestTriplesUnknownPrefix(t *testing.T) {
+	src := "---\nid: ok-page\ntype: bogus:Thing\n---\n"
+	p, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Triples("", nil); !errors.Is(err, ErrUnknownPrefix) {
+		t.Errorf("expected ErrUnknownPrefix, got %v", err)
+	}
+}

--- a/go/memory/page/triples.go
+++ b/go/memory/page/triples.go
@@ -1,0 +1,144 @@
+package page
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/soypete/ontology-go/types"
+)
+
+// Namespaces used when emitting the A-box. All standard or T-box
+// vocabularies — never invented terms (see SCHEMA.md).
+const (
+	skosNS      = "http://www.w3.org/2004/02/skos/core#"
+	skosPref    = skosNS + "prefLabel"
+	skosAlt     = skosNS + "altLabel"
+	dctermsNS   = "http://purl.org/dc/terms/"
+	dctermsSubj = dctermsNS + "subject"
+	l2wsNS      = "http://soypete.tech/l2ws/"
+	twitchNS    = "http://soypete.tech/twitch/topics/"
+
+	// DefaultBase is the default namespace for page IRIs. Callers embed the
+	// vault owner to keep A-boxes user-scoped, e.g. DefaultBase + "alice/".
+	DefaultBase = "http://soypete.tech/memory/"
+)
+
+// ErrUnknownPrefix reports a CURIE whose prefix is not in the prefix map.
+// The evaluator turns this into a DENY diagnostic listing valid prefixes.
+var ErrUnknownPrefix = errors.New("page: unknown CURIE prefix")
+
+// DefaultPrefixes returns the prefix map from SCHEMA.md plus the standard
+// RDF vocabularies.
+func DefaultPrefixes() map[string]string {
+	return map[string]string{
+		"sw":      l2wsNS,
+		"twitch":  twitchNS,
+		"skos":    skosNS,
+		"rdf":     types.RDFNS,
+		"rdfs":    types.RDFSNamespace,
+		"dcterms": dctermsNS,
+	}
+}
+
+// ExpandCURIE resolves prefix:local against prefixes.
+func ExpandCURIE(curie string, prefixes map[string]string) (string, error) {
+	prefix, local, ok := strings.Cut(curie, ":")
+	if !ok {
+		return "", fmt.Errorf("page: %q is not a CURIE", curie)
+	}
+	ns, ok := prefixes[prefix]
+	if !ok {
+		known := make([]string, 0, len(prefixes))
+		for p := range prefixes {
+			known = append(known, p)
+		}
+		sort.Strings(known)
+		return "", fmt.Errorf("%w: %q (known: %s)", ErrUnknownPrefix, prefix, strings.Join(known, ", "))
+	}
+	return ns + local, nil
+}
+
+// Triples emits the page's A-box: rdf:type, labels, topics, and all typed
+// links (frontmatter and prose). base is the IRI namespace for page ids in
+// this vault. Claims are not emitted as RDF — they stay in frontmatter and
+// feed the inference layer, not T-box validation.
+func (p *Page) Triples(base string, prefixes map[string]string) ([]types.Triple, error) {
+	if base == "" {
+		base = DefaultBase
+	}
+	if prefixes == nil {
+		prefixes = DefaultPrefixes()
+	}
+	subj := base + p.ID
+
+	var triples []types.Triple
+
+	typeIRI, err := ExpandCURIE(p.Type, prefixes)
+	if err != nil {
+		return nil, err
+	}
+	triples = append(triples, types.Triple{Subject: subj, Predicate: types.RDFType, Object: typeIRI})
+
+	for i, label := range p.Labels {
+		pred := skosAlt
+		if i == 0 {
+			pred = skosPref
+		}
+		triples = append(triples, types.Triple{Subject: subj, Predicate: pred, Object: label, IsLiteral: true})
+	}
+
+	for _, topic := range p.Topics {
+		iri, err := ExpandCURIE(topic, prefixes)
+		if err != nil {
+			return nil, err
+		}
+		triples = append(triples, types.Triple{Subject: subj, Predicate: dctermsSubj, Object: iri})
+	}
+
+	for _, link := range p.AllLinks() {
+		predIRI, err := ExpandCURIE(link.Pred, prefixes)
+		if err != nil {
+			return nil, err
+		}
+		triples = append(triples, types.Triple{Subject: subj, Predicate: predIRI, Object: base + link.Target})
+	}
+	return triples, nil
+}
+
+// WriteNTriples serializes the page's A-box to w in N-Triples format.
+func (p *Page) WriteNTriples(w io.Writer, base string, prefixes map[string]string) error {
+	triples, err := p.Triples(base, prefixes)
+	if err != nil {
+		return err
+	}
+	for _, t := range triples {
+		if _, err := io.WriteString(w, FormatNTriple(t)+"\n"); err != nil {
+			return fmt.Errorf("page: write triple: %w", err)
+		}
+	}
+	return nil
+}
+
+// FormatNTriple renders one triple as an N-Triples line (without newline).
+func FormatNTriple(t types.Triple) string {
+	obj := "<" + t.Object + ">"
+	if t.IsLiteral {
+		obj = `"` + escapeLiteral(t.Object) + `"`
+		switch {
+		case t.Language != "":
+			obj += "@" + t.Language
+		case t.Datatype != "" && t.Datatype != types.XSDString:
+			obj += "^^<" + t.Datatype + ">"
+		}
+	}
+	return fmt.Sprintf("<%s> <%s> %s .", t.Subject, t.Predicate, obj)
+}
+
+var literalEscaper = strings.NewReplacer(
+	`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`, "\t", `\t`,
+)
+
+func escapeLiteral(s string) string { return literalEscaper.Replace(s) }

--- a/go/memory/policy.go
+++ b/go/memory/policy.go
@@ -1,0 +1,88 @@
+package memory
+
+import (
+	_ "embed"
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/soypete/pedro-agentware/go/middleware"
+)
+
+//go:embed policy.yaml
+var defaultPolicyYAML []byte
+
+// yamlPolicy mirrors middleware.Policy for YAML loading. The middleware
+// types carry no YAML tags, so the mapping lives here; if a YAML loader
+// lands in the middleware package this converts to a thin wrapper.
+type yamlPolicy struct {
+	DefaultDeny bool       `yaml:"default_deny"`
+	Rules       []yamlRule `yaml:"rules"`
+}
+
+type yamlRule struct {
+	Name       string          `yaml:"name"`
+	Tools      []string        `yaml:"tools"`
+	Action     string          `yaml:"action"`
+	Conditions []yamlCondition `yaml:"conditions"`
+	MaxRate    *yamlRate       `yaml:"max_rate"`
+}
+
+type yamlCondition struct {
+	Field    string `yaml:"field"`
+	Operator string `yaml:"operator"`
+	Value    string `yaml:"value"`
+}
+
+type yamlRate struct {
+	Count         int `yaml:"count"`
+	WindowSeconds int `yaml:"window_seconds"`
+}
+
+// LoadPolicyYAML parses a declarative policy document into the stock
+// middleware Policy.
+func LoadPolicyYAML(data []byte) (*middleware.Policy, error) {
+	var yp yamlPolicy
+	if err := yaml.Unmarshal(data, &yp); err != nil {
+		return nil, fmt.Errorf("memory: parse policy yaml: %w", err)
+	}
+	p := &middleware.Policy{DefaultDeny: yp.DefaultDeny}
+	for _, yr := range yp.Rules {
+		action := middleware.Action(yr.Action)
+		switch action {
+		case middleware.ActionAllow, middleware.ActionDeny, middleware.ActionFilter:
+		default:
+			return nil, fmt.Errorf("memory: rule %q has unknown action %q", yr.Name, yr.Action)
+		}
+		rule := middleware.Rule{Name: yr.Name, Tools: yr.Tools, Action: action}
+		for _, yc := range yr.Conditions {
+			rule.Conditions = append(rule.Conditions, middleware.Condition{
+				Field:    yc.Field,
+				Operator: middleware.Operator(yc.Operator),
+				Value:    yc.Value,
+			})
+		}
+		if yr.MaxRate != nil {
+			rule.MaxRate = &middleware.RateLimit{
+				Count:  yr.MaxRate.Count,
+				Window: time.Duration(yr.MaxRate.WindowSeconds) * time.Second,
+			}
+		}
+		p.Rules = append(p.Rules, rule)
+	}
+	return p, nil
+}
+
+// DefaultPolicy returns the embedded declarative policy for memory tools:
+// deny-by-default, scope-override and anonymous-caller denies, and per-tier
+// rate limits.
+func DefaultPolicy() *middleware.Policy {
+	p, err := LoadPolicyYAML(defaultPolicyYAML)
+	if err != nil {
+		// The embedded document is compiled in; failing to parse it is a
+		// build defect, not a runtime condition.
+		panic(err)
+	}
+	return p
+}

--- a/go/memory/policy.yaml
+++ b/go/memory/policy.yaml
@@ -1,0 +1,29 @@
+# Declarative policy tier for wiki-memory tools (see SCHEMA.md).
+# Evaluated first-match-wins by the stock middleware policy engine; the
+# semantic tier (OntologyEvaluator) runs only on writes that pass this tier.
+#
+# Scope model: memory tools NEVER take a user argument — the vault is always
+# resolved from CallerContext. A user_id arg is a scope-override attempt and
+# is denied outright; anonymous callers (no caller.user_id) are denied.
+default_deny: true
+rules:
+  - name: memory-deny-scope-override
+    tools:
+      [memory_ingest, memory_write_page, memory_query, memory_get_claims, memory_lint]
+    action: deny
+    conditions:
+      - { field: args.user_id, operator: exists }
+  - name: memory-deny-anonymous
+    tools:
+      [memory_ingest, memory_write_page, memory_query, memory_get_claims, memory_lint]
+    action: deny
+    conditions:
+      - { field: caller.user_id, operator: not_exists }
+  - name: memory-writes
+    tools: [memory_ingest, memory_write_page]
+    action: allow
+    max_rate: { count: 30, window_seconds: 60 }
+  - name: memory-reads
+    tools: [memory_query, memory_get_claims, memory_lint]
+    action: allow
+    max_rate: { count: 120, window_seconds: 60 }

--- a/go/memory/query.go
+++ b/go/memory/query.go
@@ -1,0 +1,258 @@
+package memory
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/soypete/pedro-agentware/go/memory/page"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+// Structured query kinds accepted by memory_query (args.kind). Free-text
+// args.question remains the keyword fallback. These answer the L2WS
+// competency questions from memory content.
+const (
+	QueryPrerequisites   = "prerequisites"    // args: page_id
+	QueryBuildsToward    = "builds_toward"    // args: page_id
+	QueryLearningPath    = "learning_path"    // args: role (role page id)
+	QueryContestedClaims = "contested_claims" // no args
+	QueryLowConfidence   = "low_confidence"   // args: threshold (default 0.6)
+)
+
+const (
+	predRequiresPrerequisite = "sw:requiresPrerequisite"
+	predBuildsToward         = "sw:buildsToward"
+	predIsAppropriateFor     = "sw:isAppropriateFor"
+)
+
+func (x *Executor) structuredQuery(userID string, kind string, args map[string]any) (*tools.Result, error) {
+	pages, err := x.pages(userID)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]*page.Page, len(pages))
+	for _, p := range pages {
+		byID[p.ID] = p
+	}
+	switch kind {
+	case QueryPrerequisites:
+		return x.closureQuery(byID, stringArg(args, "page_id"), predRequiresPrerequisite)
+	case QueryBuildsToward:
+		return x.closureQuery(byID, stringArg(args, "page_id"), predBuildsToward)
+	case QueryLearningPath:
+		return x.learningPath(pages, byID, stringArg(args, "role"))
+	case QueryContestedClaims:
+		return x.claimFilter(pages, func(c page.Claim) bool { return c.Contested })
+	case QueryLowConfidence:
+		threshold := 0.6
+		if t, ok := args["threshold"].(float64); ok {
+			threshold = t
+		}
+		return x.claimFilter(pages, func(c page.Claim) bool {
+			return c.Confidence != nil && *c.Confidence < threshold
+		})
+	default:
+		return &tools.Result{Success: false,
+			Error: fmt.Sprintf("memory: unknown query kind %q", kind)}, nil
+	}
+}
+
+// closureQuery walks links with the given predicate transitively from a
+// page, returning targets in BFS order (nearest first). Cycle-safe.
+func (x *Executor) closureQuery(byID map[string]*page.Page, pageID, pred string) (*tools.Result, error) {
+	if _, ok := byID[pageID]; !ok {
+		return &tools.Result{Success: false,
+			Error: fmt.Sprintf("memory: page %q not found", pageID)}, nil
+	}
+	type entry struct {
+		ID    string `json:"id"`
+		Type  string `json:"type,omitempty"`
+		Depth int    `json:"depth"`
+	}
+	out := []entry{}
+	seen := map[string]bool{pageID: true}
+	frontier := []string{pageID}
+	for depth := 1; len(frontier) > 0; depth++ {
+		var next []string
+		for _, id := range frontier {
+			p, ok := byID[id]
+			if !ok {
+				continue
+			}
+			for _, link := range p.AllLinks() {
+				if link.Pred != pred || seen[link.Target] {
+					continue
+				}
+				seen[link.Target] = true
+				pageType := ""
+				if tp, ok := byID[link.Target]; ok {
+					pageType = tp.Type
+				}
+				out = append(out, entry{ID: link.Target, Type: pageType, Depth: depth})
+				next = append(next, link.Target)
+			}
+		}
+		frontier = next
+	}
+	return jsonResult(out)
+}
+
+// learningPath lists the skills appropriate for a role, ordered so that
+// prerequisites come before the skills that require them.
+func (x *Executor) learningPath(pages []*page.Page, byID map[string]*page.Page, roleID string) (*tools.Result, error) {
+	if roleID == "" {
+		return &tools.Result{Success: false, Error: "memory: learning_path requires args.role"}, nil
+	}
+	relevant := map[string]bool{}
+	for _, p := range pages {
+		for _, link := range p.AllLinks() {
+			if link.Pred == predIsAppropriateFor && link.Target == roleID {
+				relevant[p.ID] = true
+			}
+		}
+	}
+	// Include transitive prerequisites of every relevant skill.
+	queue := make([]string, 0, len(relevant))
+	for id := range relevant {
+		queue = append(queue, id)
+	}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		p, ok := byID[id]
+		if !ok {
+			continue
+		}
+		for _, link := range p.AllLinks() {
+			if link.Pred == predRequiresPrerequisite && !relevant[link.Target] {
+				relevant[link.Target] = true
+				queue = append(queue, link.Target)
+			}
+		}
+	}
+	ordered := topoByPrerequisite(relevant, byID)
+	type step struct {
+		ID    string `json:"id"`
+		Type  string `json:"type,omitempty"`
+		Label string `json:"label,omitempty"`
+	}
+	out := []step{}
+	for _, id := range ordered {
+		s := step{ID: id}
+		if p, ok := byID[id]; ok {
+			s.Type = p.Type
+			if len(p.Labels) > 0 {
+				s.Label = p.Labels[0]
+			}
+		}
+		out = append(out, s)
+	}
+	return jsonResult(out)
+}
+
+// topoByPrerequisite orders page ids so prerequisites precede dependents;
+// ties break alphabetically. Cycles cannot occur (the evaluator rejects
+// them at write time), but the sort degrades gracefully if one appears.
+func topoByPrerequisite(ids map[string]bool, byID map[string]*page.Page) []string {
+	indegree := map[string]int{}
+	dependents := map[string][]string{}
+	for id := range ids {
+		indegree[id] += 0
+		p, ok := byID[id]
+		if !ok {
+			continue
+		}
+		for _, link := range p.AllLinks() {
+			if link.Pred == predRequiresPrerequisite && ids[link.Target] {
+				indegree[id]++
+				dependents[link.Target] = append(dependents[link.Target], id)
+			}
+		}
+	}
+	ready := []string{}
+	for id, deg := range indegree {
+		if deg == 0 {
+			ready = append(ready, id)
+		}
+	}
+	sort.Strings(ready)
+	var out []string
+	for len(ready) > 0 {
+		id := ready[0]
+		ready = ready[1:]
+		out = append(out, id)
+		next := dependents[id]
+		sort.Strings(next)
+		for _, dep := range next {
+			indegree[dep]--
+			if indegree[dep] == 0 {
+				ready = append(ready, dep)
+			}
+		}
+	}
+	if len(out) < len(indegree) { // cycle remnant: append leftovers stably
+		var rest []string
+		for id := range indegree {
+			if !slices.Contains(out, id) {
+				rest = append(rest, id)
+			}
+		}
+		sort.Strings(rest)
+		out = append(out, rest...)
+	}
+	return out
+}
+
+func (x *Executor) claimFilter(pages []*page.Page, keep func(page.Claim) bool) (*tools.Result, error) {
+	type claimOut struct {
+		Page       string   `json:"page"`
+		ID         string   `json:"id"`
+		Text       string   `json:"text"`
+		Confidence *float64 `json:"confidence"`
+		Contested  bool     `json:"contested,omitempty"`
+	}
+	out := []claimOut{}
+	for _, p := range pages {
+		for _, c := range p.Claims {
+			if keep(c) {
+				out = append(out, claimOut{Page: p.ID, ID: c.ID, Text: c.Text,
+					Confidence: c.Confidence, Contested: c.Contested})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Page != out[j].Page {
+			return out[i].Page < out[j].Page
+		}
+		return out[i].ID < out[j].ID
+	})
+	return jsonResult(out)
+}
+
+// keywordQuery is the free-text fallback: match on page id, labels, topics.
+func (x *Executor) keywordQuery(userID, question string) (*tools.Result, error) {
+	q := strings.ToLower(question)
+	pages, err := x.pages(userID)
+	if err != nil {
+		return nil, err
+	}
+	type hit struct {
+		ID     string   `json:"id"`
+		Type   string   `json:"type"`
+		Labels []string `json:"labels,omitempty"`
+	}
+	hits := []hit{}
+	for _, p := range pages {
+		haystack := strings.ToLower(p.ID + " " + strings.Join(p.Labels, " ") + " " + strings.Join(p.Topics, " "))
+		for word := range strings.FieldsSeq(q) {
+			if strings.Contains(haystack, word) {
+				hits = append(hits, hit{ID: p.ID, Type: p.Type, Labels: p.Labels})
+				break
+			}
+		}
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].ID < hits[j].ID })
+	return jsonResult(hits)
+}

--- a/go/memory/query_test.go
+++ b/go/memory/query_test.go
@@ -1,0 +1,146 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// buildLearningVault writes a small skill graph through the enforced path:
+//
+//	goroutines <-requiresPrerequisite- channels <-req- go-worker-pools
+//	go-worker-pools -buildsToward-> go-concurrency ; both appropriate for
+//	backend-engineer (a sw:Role page). Claims carry confidence/contested.
+func buildLearningVault(t *testing.T, w *WikiMemory) context.Context {
+	t.Helper()
+	ctx := callerCtx("alice")
+	pages := []string{
+		"---\nid: backend-engineer\ntype: sw:Role\nlabels: [\"Backend Engineer\"]\n---\n",
+		"---\nid: goroutines\ntype: sw:Skill\nlabels: [\"Goroutines\"]\n---\n",
+		"---\nid: channels\ntype: sw:Skill\nlabels: [\"Channels\"]\nlinks:\n" +
+			"  - {pred: sw:requiresPrerequisite, target: goroutines}\n---\n",
+		"---\nid: go-concurrency\ntype: sw:Skill\nlabels: [\"Advanced Concurrency\"]\n" +
+			"links:\n  - {pred: sw:isAppropriateFor, target: backend-engineer}\n---\n",
+		"---\nid: go-worker-pools\ntype: sw:Skill\nlabels: [\"Worker Pools\"]\nlinks:\n" +
+			"  - {pred: sw:requiresPrerequisite, target: channels}\n" +
+			"  - {pred: sw:buildsToward, target: go-concurrency}\n" +
+			"  - {pred: sw:isAppropriateFor, target: backend-engineer}\n" +
+			"claims:\n" +
+			"  - {id: c1, text: \"Pools prevent leaks\", confidence: 0.94}\n" +
+			"  - {id: c2, text: \"Leaks are harmless\", confidence: 0.21, contested: true}\n" +
+			"  - {id: c3, text: \"Pools are slower than unbounded spawning\", confidence: 0.4}\n---\n",
+	}
+	for _, content := range pages {
+		res, err := w.Execute(ctx, ToolWritePage, map[string]any{"content": content})
+		if err != nil || !res.Success {
+			t.Fatalf("write failed: %+v %v", res, err)
+		}
+	}
+	return ctx
+}
+
+func structQuery(t *testing.T, w *WikiMemory, ctx context.Context, args map[string]any) []map[string]any {
+	t.Helper()
+	res, err := w.Execute(ctx, ToolQuery, args)
+	if err != nil || !res.Success {
+		t.Fatalf("query %v failed: %+v %v", args, res, err)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal([]byte(res.Output), &out); err != nil {
+		t.Fatalf("bad query output %q: %v", res.Output, err)
+	}
+	return out
+}
+
+func ids(rows []map[string]any) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = fmt.Sprint(r["id"])
+	}
+	return out
+}
+
+func TestQueryPrerequisitesTransitive(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := buildLearningVault(t, w)
+	rows := structQuery(t, w, ctx, map[string]any{
+		"kind": QueryPrerequisites, "page_id": "go-worker-pools",
+	})
+	if got := ids(rows); len(got) != 2 || got[0] != "channels" || got[1] != "goroutines" {
+		t.Errorf("prerequisites = %v, want [channels goroutines] (BFS order)", got)
+	}
+	if rows[1]["depth"].(float64) != 2 {
+		t.Errorf("goroutines should be depth 2, got %v", rows[1]["depth"])
+	}
+}
+
+func TestQueryBuildsToward(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := buildLearningVault(t, w)
+	rows := structQuery(t, w, ctx, map[string]any{
+		"kind": QueryBuildsToward, "page_id": "go-worker-pools",
+	})
+	if got := ids(rows); len(got) != 1 || got[0] != "go-concurrency" {
+		t.Errorf("builds_toward = %v, want [go-concurrency]", got)
+	}
+}
+
+func TestQueryLearningPathTopologicalOrder(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := buildLearningVault(t, w)
+	rows := structQuery(t, w, ctx, map[string]any{
+		"kind": QueryLearningPath, "role": "backend-engineer",
+	})
+	got := ids(rows)
+	// Prerequisites first: goroutines before channels before worker pools;
+	// go-concurrency has no prerequisites so it sorts among the roots.
+	index := map[string]int{}
+	for i, id := range got {
+		index[id] = i
+	}
+	for _, pair := range [][2]string{
+		{"goroutines", "channels"}, {"channels", "go-worker-pools"},
+	} {
+		if index[pair[0]] >= index[pair[1]] {
+			t.Errorf("learning path %v must place %s before %s", got, pair[0], pair[1])
+		}
+	}
+	if len(got) != 4 {
+		t.Errorf("learning path should cover appropriate skills plus transitive prerequisites, got %v", got)
+	}
+}
+
+func TestQueryContestedAndLowConfidenceClaims(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := buildLearningVault(t, w)
+	contested := structQuery(t, w, ctx, map[string]any{"kind": QueryContestedClaims})
+	if len(contested) != 1 || contested[0]["id"] != "c2" {
+		t.Errorf("contested claims = %v, want [c2]", contested)
+	}
+	low := structQuery(t, w, ctx, map[string]any{"kind": QueryLowConfidence})
+	if got := ids(low); len(got) != 2 || got[0] != "c2" || got[1] != "c3" {
+		t.Errorf("low confidence = %v, want [c2 c3]", got)
+	}
+	strict := structQuery(t, w, ctx, map[string]any{
+		"kind": QueryLowConfidence, "threshold": 0.3,
+	})
+	if got := ids(strict); len(got) != 1 || got[0] != "c2" {
+		t.Errorf("low confidence @0.3 = %v, want [c2]", got)
+	}
+}
+
+func TestQueryUnknownKindAndMissingPage(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := buildLearningVault(t, w)
+	res, err := w.Execute(ctx, ToolQuery, map[string]any{"kind": "bogus"})
+	if err != nil || res.Success {
+		t.Errorf("unknown kind must fail cleanly: %+v %v", res, err)
+	}
+	res, err = w.Execute(ctx, ToolQuery, map[string]any{
+		"kind": QueryPrerequisites, "page_id": "no-such-page",
+	})
+	if err != nil || res.Success {
+		t.Errorf("missing page must fail cleanly: %+v %v", res, err)
+	}
+}

--- a/go/memory/tools.go
+++ b/go/memory/tools.go
@@ -15,8 +15,10 @@ func Tools() []string {
 	return []string{ToolIngest, ToolWritePage, ToolQuery, ToolGetClaims, ToolLint}
 }
 
-// writeTools are the tools whose args carry page content subject to
-// semantic (ontology) validation.
-func isWriteTool(name string) bool {
-	return name == ToolIngest || name == ToolWritePage
+// isSemanticWrite reports whether a tool's args carry wiki-page content
+// subject to ontology validation. memory_ingest stores raw source text
+// verbatim, so only page writes get the semantic tier; both pass the
+// declarative tier and are audited.
+func isSemanticWrite(name string) bool {
+	return name == ToolWritePage
 }

--- a/go/memory/tools.go
+++ b/go/memory/tools.go
@@ -1,0 +1,22 @@
+package memory
+
+// Memory tool names. These are the MCP tool identifiers served by the Go
+// core; the declarative policy and the OntologyEvaluator key off them.
+const (
+	ToolIngest    = "memory_ingest"
+	ToolWritePage = "memory_write_page"
+	ToolQuery     = "memory_query"
+	ToolGetClaims = "memory_get_claims"
+	ToolLint      = "memory_lint"
+)
+
+// Tools lists every memory tool name.
+func Tools() []string {
+	return []string{ToolIngest, ToolWritePage, ToolQuery, ToolGetClaims, ToolLint}
+}
+
+// writeTools are the tools whose args carry page content subject to
+// semantic (ontology) validation.
+func isWriteTool(name string) bool {
+	return name == ToolIngest || name == ToolWritePage
+}

--- a/go/memory/vault.go
+++ b/go/memory/vault.go
@@ -1,0 +1,171 @@
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	// ErrInvalidUserID reports a user ID that is empty or unsafe as a
+	// directory name.
+	ErrInvalidUserID = errors.New("memory: invalid user id")
+	// ErrInvalidPageID reports a page ID that is not kebab-case.
+	ErrInvalidPageID = errors.New("memory: invalid page id")
+	// ErrOutsideVault reports a resolved path that escapes the caller's
+	// vault. This is the path-boundary half of the cross-user isolation
+	// guarantee (the policy rule is the other half).
+	ErrOutsideVault = errors.New("memory: path escapes user vault")
+)
+
+// userIDPattern intentionally excludes path separators, "..", and leading
+// dots. It admits typical user IDs (login names, emails, UUIDs).
+var userIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_@.-]*$`)
+
+// pageIDPattern is the kebab-case contract from SCHEMA.md.
+var pageIDPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+const (
+	wikiDirName = "wiki"
+	rawDirName  = "raw"
+	indexFile   = "index.md"
+	logFile     = "log.md"
+)
+
+// Vault resolves per-user wiki directories under a single memory root.
+// It performs no policy evaluation; it only guarantees that every path it
+// returns is inside the vault of the user it was asked about.
+type Vault struct {
+	root string
+}
+
+// NewVault returns a Vault rooted at dir. The directory is created if it
+// does not exist.
+func NewVault(dir string) (*Vault, error) {
+	if dir == "" {
+		return nil, errors.New("memory: vault root must not be empty")
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("memory: resolve vault root: %w", err)
+	}
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return nil, fmt.Errorf("memory: create vault root: %w", err)
+	}
+	return &Vault{root: abs}, nil
+}
+
+// Root returns the memory root directory.
+func (v *Vault) Root() string { return v.root }
+
+// UserRoot returns the vault directory for userID without creating it.
+func (v *Vault) UserRoot(userID string) (string, error) {
+	if !userIDPattern.MatchString(userID) || strings.Contains(userID, "..") {
+		return "", fmt.Errorf("%w: %q", ErrInvalidUserID, userID)
+	}
+	return v.contain(filepath.Join(v.root, userID))
+}
+
+// WikiDir returns the wiki directory for userID.
+func (v *Vault) WikiDir(userID string) (string, error) {
+	userRoot, err := v.UserRoot(userID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userRoot, wikiDirName), nil
+}
+
+// RawDir returns the raw-sources directory for userID.
+func (v *Vault) RawDir(userID string) (string, error) {
+	userRoot, err := v.UserRoot(userID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userRoot, rawDirName), nil
+}
+
+// PagePath resolves the on-disk path of a wiki page. pageID must be
+// kebab-case per the frontmatter contract; the resolved path must stay
+// inside the user's wiki directory.
+func (v *Vault) PagePath(userID, pageID string) (string, error) {
+	wiki, err := v.WikiDir(userID)
+	if err != nil {
+		return "", err
+	}
+	if !pageIDPattern.MatchString(pageID) {
+		return "", fmt.Errorf("%w: %q", ErrInvalidPageID, pageID)
+	}
+	path, err := v.containIn(wiki, filepath.Join(wiki, pageID+".md"))
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// EnsureUser creates the user's vault layout (wiki/ with seeded index.md
+// and log.md, and raw/) if it does not already exist. It is idempotent and
+// never overwrites existing files.
+func (v *Vault) EnsureUser(userID string) error {
+	wiki, err := v.WikiDir(userID)
+	if err != nil {
+		return err
+	}
+	raw, err := v.RawDir(userID)
+	if err != nil {
+		return err
+	}
+	for _, dir := range []string{wiki, raw} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("memory: create %s: %w", dir, err)
+		}
+	}
+	seeds := map[string]string{
+		filepath.Join(wiki, indexFile): "# Wiki Index\n\nNo pages yet.\n",
+		filepath.Join(wiki, logFile):   "# Maintenance Log\n",
+	}
+	for path, content := range seeds {
+		if _, err := os.Stat(path); err == nil {
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("memory: stat %s: %w", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("memory: seed %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// Contains reports whether path (after cleaning) lies inside the vault of
+// userID. Executors use this as the defense-in-depth check before any
+// filesystem operation.
+func (v *Vault) Contains(userID, path string) bool {
+	userRoot, err := v.UserRoot(userID)
+	if err != nil {
+		return false
+	}
+	if _, err := v.containIn(userRoot, path); err != nil {
+		return false
+	}
+	return true
+}
+
+func (v *Vault) contain(path string) (string, error) {
+	return v.containIn(v.root, path)
+}
+
+// containIn cleans path and verifies it is base itself or a descendant.
+func (v *Vault) containIn(base, path string) (string, error) {
+	abs, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", fmt.Errorf("memory: resolve path: %w", err)
+	}
+	rel, err := filepath.Rel(base, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q outside %q", ErrOutsideVault, path, base)
+	}
+	return abs, nil
+}

--- a/go/memory/vault_test.go
+++ b/go/memory/vault_test.go
@@ -1,0 +1,117 @@
+package memory
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestVault(t *testing.T) *Vault {
+	t.Helper()
+	v, err := NewVault(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewVault: %v", err)
+	}
+	return v
+}
+
+func TestEnsureUserSeedsLayout(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.EnsureUser("alice"); err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	wiki, _ := v.WikiDir("alice")
+	raw, _ := v.RawDir("alice")
+	for _, path := range []string{
+		filepath.Join(wiki, "index.md"),
+		filepath.Join(wiki, "log.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected seeded file %s: %v", path, err)
+		}
+	}
+	if info, err := os.Stat(raw); err != nil || !info.IsDir() {
+		t.Errorf("expected raw dir %s: %v", raw, err)
+	}
+}
+
+func TestEnsureUserIdempotentAndNonDestructive(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.EnsureUser("alice"); err != nil {
+		t.Fatalf("EnsureUser: %v", err)
+	}
+	wiki, _ := v.WikiDir("alice")
+	index := filepath.Join(wiki, "index.md")
+	if err := os.WriteFile(index, []byte("edited"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.EnsureUser("alice"); err != nil {
+		t.Fatalf("EnsureUser second call: %v", err)
+	}
+	data, err := os.ReadFile(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "edited" {
+		t.Errorf("EnsureUser overwrote existing index.md: %q", data)
+	}
+}
+
+func TestUserRootRejectsUnsafeIDs(t *testing.T) {
+	v := newTestVault(t)
+	for _, id := range []string{
+		"", "..", "../alice", "alice/bob", "a/../../etc", ".hidden",
+		"alice\x00", "/abs",
+	} {
+		if _, err := v.UserRoot(id); err == nil {
+			t.Errorf("UserRoot(%q): expected error, got nil", id)
+		}
+	}
+	for _, id := range []string{"alice", "user@example.com", "a-b_c.d", "42"} {
+		if _, err := v.UserRoot(id); err != nil {
+			t.Errorf("UserRoot(%q): unexpected error %v", id, err)
+		}
+	}
+}
+
+func TestPagePathEnforcesKebabCaseAndContainment(t *testing.T) {
+	v := newTestVault(t)
+	path, err := v.PagePath("alice", "go-worker-pools")
+	if err != nil {
+		t.Fatalf("PagePath: %v", err)
+	}
+	if !strings.HasSuffix(path, filepath.Join("alice", "wiki", "go-worker-pools.md")) {
+		t.Errorf("unexpected page path %s", path)
+	}
+	for _, id := range []string{
+		"", "UPPER", "has space", "trailing-", "-leading", "a..b",
+		"../escape", "nested/page", "double--dash",
+	} {
+		if _, err := v.PagePath("alice", id); !errors.Is(err, ErrInvalidPageID) {
+			t.Errorf("PagePath(%q): expected ErrInvalidPageID, got %v", id, err)
+		}
+	}
+}
+
+func TestContainsRejectsCrossUserPaths(t *testing.T) {
+	v := newTestVault(t)
+	alicePage, err := v.PagePath("alice", "notes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !v.Contains("alice", alicePage) {
+		t.Errorf("Contains should accept alice's own page")
+	}
+	if v.Contains("bob", alicePage) {
+		t.Errorf("Contains must reject alice's page for bob")
+	}
+	sneaky := filepath.Join(v.Root(), "bob", "..", "alice", "wiki", "notes.md")
+	if v.Contains("bob", sneaky) {
+		t.Errorf("Contains must reject traversal into another user's vault")
+	}
+	if v.Contains("alice", filepath.Join(v.Root(), "..", "outside.md")) {
+		t.Errorf("Contains must reject paths outside the memory root")
+	}
+}

--- a/go/memory/wiki.go
+++ b/go/memory/wiki.go
@@ -1,0 +1,113 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/soypete/pedro-agentware/go/memory/ontology"
+	"github.com/soypete/pedro-agentware/go/middleware"
+	"github.com/soypete/pedro-agentware/go/tools"
+)
+
+// Config configures the composable wiki-memory component.
+type Config struct {
+	// Root is the memory root directory (one vault per user beneath it).
+	Root string
+	// TBoxPaths are Turtle files forming the read-only T-box. Defaults to
+	// the ontologies/ submodule paths when empty relative to the repo; there
+	// is no implicit default outside it — users point at their own T-box.
+	TBoxPaths []string
+	// Prefixes overrides the CURIE prefix map (SCHEMA.md defaults).
+	Prefixes map[string]string
+	// Policy overrides the embedded declarative policy.
+	Policy *middleware.Policy
+	// Auditor records every decision. Defaults to an in-memory auditor.
+	Auditor middleware.Auditor
+}
+
+// WikiMemory is the enabled component: the five memory tools behind the
+// standard middleware chain (declarative policy + ontology evaluator +
+// auditor). Enable it and register its tools; every call is enforced and
+// audited.
+type WikiMemory struct {
+	vault   *Vault
+	tbox    *ontology.TBox
+	exec    *Executor
+	auditor middleware.Auditor
+	chain   middleware.Middleware
+}
+
+// Enable builds the component: vault, T-box, executor, evaluator, and the
+// middleware chain wired as NewMiddleware(exec).WithPolicy(...).WithAuditor(...).
+func Enable(cfg Config) (*WikiMemory, error) {
+	if len(cfg.TBoxPaths) == 0 {
+		return nil, fmt.Errorf("memory: Config.TBoxPaths is required (the T-box is a parameter, e.g. the ontologies/ submodule files)")
+	}
+	vault, err := NewVault(cfg.Root)
+	if err != nil {
+		return nil, err
+	}
+	tbox, err := ontology.Load(cfg.TBoxPaths...)
+	if err != nil {
+		return nil, err
+	}
+	exec := NewExecutor(vault, tbox, cfg.Prefixes)
+	opts := []EvaluatorOption{WithVaultReader(exec)}
+	if cfg.Prefixes != nil {
+		opts = append(opts, WithPrefixes(cfg.Prefixes))
+	}
+	if cfg.Policy != nil {
+		opts = append(opts, WithDeclarativePolicy(cfg.Policy))
+	}
+	auditor := cfg.Auditor
+	if auditor == nil {
+		auditor = middleware.NewInMemoryAuditor()
+	}
+	chain := middleware.NewMiddleware(exec).
+		WithPolicy(NewOntologyEvaluator(tbox, opts...)).
+		WithAuditor(auditor)
+	return &WikiMemory{vault: vault, tbox: tbox, exec: exec, auditor: auditor, chain: chain}, nil
+}
+
+// Execute runs a memory tool through the enforced chain. The caller must be
+// attached to ctx via middleware.WithCallerContext.
+func (w *WikiMemory) Execute(ctx context.Context, toolName string, args map[string]any) (*tools.Result, error) {
+	return w.chain.Execute(ctx, toolName, args)
+}
+
+// Auditor returns the auditor recording this component's decisions.
+func (w *WikiMemory) Auditor() middleware.Auditor { return w.auditor }
+
+// Vault returns the underlying vault (path resolution only; writes must go
+// through Execute).
+func (w *WikiMemory) Vault() *Vault { return w.vault }
+
+// TBox returns the loaded terminology.
+func (w *WikiMemory) TBox() *ontology.TBox { return w.tbox }
+
+// RegisterTools registers the five memory tools on a tool registry, each
+// dispatching through the enforced chain.
+func (w *WikiMemory) RegisterTools(registry *tools.ToolRegistry) {
+	descriptions := map[string]string{
+		ToolIngest:    "Store a raw source document in the caller's memory vault (args: source_id, text).",
+		ToolWritePage: "Create or update an ontology-validated wiki page in the caller's vault (args: content, optional page_id).",
+		ToolQuery:     "Query the caller's wiki memory (args: question).",
+		ToolGetClaims: "List claims tracked in the caller's vault (args: optional page_id).",
+		ToolLint:      "Report contract, ontology, and graph issues in the caller's vault.",
+	}
+	for _, name := range Tools() {
+		registry.Register(&memoryTool{name: name, description: descriptions[name], wiki: w})
+	}
+}
+
+type memoryTool struct {
+	name        string
+	description string
+	wiki        *WikiMemory
+}
+
+func (t *memoryTool) Name() string        { return t.name }
+func (t *memoryTool) Description() string { return t.description }
+func (t *memoryTool) Execute(ctx context.Context, args map[string]any) (*tools.Result, error) {
+	return t.wiki.Execute(ctx, t.name, args)
+}

--- a/go/memory/wiki_test.go
+++ b/go/memory/wiki_test.go
@@ -1,0 +1,217 @@
+package memory
+
+// End-to-end tests of the enforced chain: Enable() wiring, allow/deny
+// through the middleware, audit records, and cross-user isolation.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/soypete/pedro-agentware/go/memory/ontology"
+	"github.com/soypete/pedro-agentware/go/middleware"
+)
+
+func enableTestMemory(t *testing.T) *WikiMemory {
+	t.Helper()
+	w, err := Enable(Config{
+		Root:      t.TempDir(),
+		TBoxPaths: []string{tboxEducation, tboxTopics},
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "ontologies") {
+			t.Skipf("T-box unavailable (run: git submodule update --init): %v", err)
+		}
+		t.Fatal(err)
+	}
+	return w
+}
+
+func callerCtx(userID string) context.Context {
+	return middleware.WithCallerContext(context.Background(), middleware.CallerContext{
+		UserID: userID, SessionID: "sess-" + userID, Trusted: true,
+	})
+}
+
+const workerPoolsPage = `---
+id: go-worker-pools
+type: sw:Skill
+labels: ["Worker Pools"]
+topics: [twitch:Go]
+claims:
+  - {id: c1, text: "Bounded pools prevent goroutine leaks", sources: [src-talk]}
+---
+Pools bound concurrency.
+`
+
+func TestChainValidWriteAllowedAndPersisted(t *testing.T) {
+	w := enableTestMemory(t)
+	res, err := w.Execute(callerCtx("alice"), ToolWritePage, map[string]any{"content": workerPoolsPage})
+	if err != nil || !res.Success {
+		t.Fatalf("expected successful write, got res=%+v err=%v", res, err)
+	}
+	path, _ := w.Vault().PagePath("alice", "go-worker-pools")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("page not persisted: %v", err)
+	}
+	wiki, _ := w.Vault().WikiDir("alice")
+	index, err := os.ReadFile(filepath.Join(wiki, "index.md"))
+	if err != nil || !strings.Contains(string(index), "go-worker-pools") {
+		t.Errorf("index.md not refreshed: %v %q", err, index)
+	}
+	logData, err := os.ReadFile(filepath.Join(wiki, "log.md"))
+	if err != nil || !strings.Contains(string(logData), "wrote page go-worker-pools") {
+		t.Errorf("log.md not appended: %v %q", err, logData)
+	}
+}
+
+func TestChainDenyCarriesDiagnosticsAndIsAudited(t *testing.T) {
+	w := enableTestMemory(t)
+	bad := "---\nid: bad-page\ntype: sw:Skil\n---\n"
+	res, err := w.Execute(callerCtx("alice"), ToolWritePage, map[string]any{"content": bad})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Success {
+		t.Fatal("expected policy denial")
+	}
+	vs, ok := ParseDiagnostics(res.Error)
+	if !ok || vs[0].Constraint != ontology.ConstraintUnknownClass || len(vs[0].Nearest) == 0 {
+		t.Errorf("expected unknown-class diagnostics with nearest terms in %q", res.Error)
+	}
+	denies := w.Auditor().Query(middleware.AuditFilter{Action: middleware.ActionDeny})
+	if len(denies) != 1 {
+		t.Fatalf("expected 1 audited deny, got %d", len(denies))
+	}
+	if denies[0].ToolName != ToolWritePage || denies[0].SessionID != "sess-alice" {
+		t.Errorf("audit record mismatch: %+v", denies[0])
+	}
+	if _, ok := ParseDiagnostics(denies[0].Decision.Reason); !ok {
+		t.Error("audited deny must carry the diagnostics payload")
+	}
+}
+
+func TestChainDeniesCycleThroughRealVault(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := callerCtx("alice")
+	a := "---\nid: a-page\ntype: sw:Skill\nlinks:\n  - {pred: skos:broader, target: b-page}\n---\n"
+	if res, err := w.Execute(ctx, ToolWritePage, map[string]any{"content": a}); err != nil || !res.Success {
+		t.Fatalf("first write should pass (dangling target allowed): %+v %v", res, err)
+	}
+	b := "---\nid: b-page\ntype: sw:Skill\nlinks:\n  - {pred: skos:broader, target: a-page}\n---\n"
+	res, err := w.Execute(ctx, ToolWritePage, map[string]any{"content": b})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Success {
+		t.Fatal("cycle-introducing write must be denied")
+	}
+	vs, ok := ParseDiagnostics(res.Error)
+	if !ok {
+		t.Fatalf("expected diagnostics, got %q", res.Error)
+	}
+	found := false
+	for _, v := range vs {
+		if v.Constraint == ontology.ConstraintSKOSCycle {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected skos-cycle violation, got %v", vs)
+	}
+}
+
+func TestChainUserIsolation(t *testing.T) {
+	w := enableTestMemory(t)
+	if res, err := w.Execute(callerCtx("alice"), ToolWritePage, map[string]any{"content": workerPoolsPage}); err != nil || !res.Success {
+		t.Fatalf("alice write failed: %+v %v", res, err)
+	}
+
+	// Policy half: bob cannot redirect scope via args.
+	res, err := w.Execute(callerCtx("bob"), ToolQuery, map[string]any{
+		"question": "worker pools", "user_id": "alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Success || !strings.Contains(res.Error, "memory-deny-scope-override") &&
+		!strings.Contains(res.Error, "denied by policy") {
+		t.Errorf("scope-override must be denied, got %+v", res)
+	}
+
+	// Scoping half: bob's own query sees nothing of alice's vault.
+	res, err = w.Execute(callerCtx("bob"), ToolQuery, map[string]any{"question": "worker pools"})
+	if err != nil || !res.Success {
+		t.Fatalf("bob query failed: %+v %v", res, err)
+	}
+	if strings.Contains(res.Output, "go-worker-pools") {
+		t.Errorf("bob must not see alice's pages, got %s", res.Output)
+	}
+
+	// Path half: alice's page exists only under alice's vault, and the
+	// vault refuses alice's path for bob.
+	alicePage, _ := w.Vault().PagePath("alice", "go-worker-pools")
+	if w.Vault().Contains("bob", alicePage) {
+		t.Error("vault must reject alice's page path for bob")
+	}
+	// Claims are scoped the same way.
+	res, err = w.Execute(callerCtx("bob"), ToolGetClaims, map[string]any{})
+	if err != nil || !res.Success {
+		t.Fatalf("bob get_claims failed: %+v %v", res, err)
+	}
+	if strings.Contains(res.Output, "goroutine leaks") {
+		t.Errorf("bob must not see alice's claims, got %s", res.Output)
+	}
+}
+
+func TestChainAnonymousDeniedBeforeExecutor(t *testing.T) {
+	w := enableTestMemory(t)
+	res, err := w.Execute(context.Background(), ToolQuery, map[string]any{"question": "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Success {
+		t.Error("anonymous call must be denied by policy")
+	}
+}
+
+func TestChainIngestAndClaims(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := callerCtx("alice")
+	res, err := w.Execute(ctx, ToolIngest, map[string]any{"source_id": "src-talk", "text": "raw notes"})
+	if err != nil || !res.Success {
+		t.Fatalf("ingest failed: %+v %v", res, err)
+	}
+	raw, _ := w.Vault().RawDir("alice")
+	if _, err := os.Stat(filepath.Join(raw, "src-talk.md")); err != nil {
+		t.Errorf("raw source not stored: %v", err)
+	}
+	if res, err := w.Execute(ctx, ToolWritePage, map[string]any{"content": workerPoolsPage}); err != nil || !res.Success {
+		t.Fatalf("write failed: %+v %v", res, err)
+	}
+	res, err = w.Execute(ctx, ToolGetClaims, map[string]any{"page_id": "go-worker-pools"})
+	if err != nil || !res.Success {
+		t.Fatalf("get_claims failed: %+v %v", res, err)
+	}
+	if !strings.Contains(res.Output, "goroutine leaks") || !strings.Contains(res.Output, `"confidence": null`) {
+		t.Errorf("claims output missing fields: %s", res.Output)
+	}
+}
+
+func TestChainLintReportsDanglingLink(t *testing.T) {
+	w := enableTestMemory(t)
+	ctx := callerCtx("alice")
+	a := "---\nid: a-page\ntype: sw:Skill\nlinks:\n  - {pred: skos:related, target: no-such-page}\n---\n"
+	if res, err := w.Execute(ctx, ToolWritePage, map[string]any{"content": a}); err != nil || !res.Success {
+		t.Fatalf("write failed: %+v %v", res, err)
+	}
+	res, err := w.Execute(ctx, ToolLint, map[string]any{})
+	if err != nil || !res.Success {
+		t.Fatalf("lint failed: %+v %v", res, err)
+	}
+	if !strings.Contains(res.Output, "dangling-link") || !strings.Contains(res.Output, "no-such-page") {
+		t.Errorf("lint must report the dangling link, got %s", res.Output)
+	}
+}

--- a/go/middleware/middleware.go
+++ b/go/middleware/middleware.go
@@ -90,3 +90,10 @@ const callerContextKey contextKey = "caller_context"
 func WithCallerContext(ctx context.Context, caller CallerContext) context.Context {
 	return context.WithValue(ctx, callerContextKey, caller)
 }
+
+// CallerFromContext returns the CallerContext attached to ctx, if any.
+// Downstream executors use this to scope work to the calling user.
+func CallerFromContext(ctx context.Context) (CallerContext, bool) {
+	c, ok := ctx.Value(callerContextKey).(CallerContext)
+	return c, ok
+}

--- a/python/examples/wiki_memory_dogfood.py
+++ b/python/examples/wiki_memory_dogfood.py
@@ -156,6 +156,18 @@ def run(root: str) -> dict[str, Any]:
         assert out == "wrote go-worker-pools", out
         final_claims = memory.get_claims("go-worker-pools")[0]
 
+        # 5. Query the memory: contested claims and low-confidence claims.
+        contested_text, ok, err = memory.execute(
+            "memory_query", {"kind": "contested_claims"}
+        )
+        assert ok, err
+        contested_query = json.loads(contested_text)
+        low_text, ok, err = memory.execute(
+            "memory_query", {"kind": "low_confidence", "threshold": 0.6}
+        )
+        assert ok, err
+        low_confidence_query = json.loads(low_text)
+
     c1 = claim_node_id("go-worker-pools", "c1")
     c3 = claim_node_id("go-worker-pools", "c3")
     return {
@@ -169,6 +181,8 @@ def run(root: str) -> dict[str, Any]:
             c["id"]: {"confidence": c["confidence"], "contested": c.get("contested", False)}
             for c in final_claims
         },
+        "contested_query": [c["id"] for c in contested_query],
+        "low_confidence_query": [c["id"] for c in low_confidence_query],
         "method": response["method"],
     }
 

--- a/python/examples/wiki_memory_dogfood.py
+++ b/python/examples/wiki_memory_dogfood.py
@@ -1,0 +1,187 @@
+"""Dogfood: an agent maintains one user's wiki memory via the enforced path.
+
+Walks the full loop with the real Go core (memctl serve over MCP stdio) and
+the real inference engine (pgmpy):
+
+1. Ingest three overlapping sources on Go concurrency.
+2. Write pages through memory_write_page — the first attempt uses a topic
+   term the ontology rejects, so the agent reads the DENY diagnostics,
+   corrects itself, and retries (the deny→retry cycle is logged).
+3. Ingest a fourth source that CONTRADICTS an earlier claim and record the
+   contradicting claim.
+4. Build the Markov link network from the vault's claims, run inference,
+   and write confidence back through the enforced path.
+
+Run: PEDRO_MEMCTL=/path/to/memctl python examples/wiki_memory_dogfood.py
+
+The tool surface used here is exactly what a LangGraph agent gets from
+LangGraphMemoryTools; this script plays the agent's tool calls determinis-
+tically so the flow is testable without a live LLM.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from pedro_agentware.memory import (
+    LangGraphMemoryTools,
+    WikiMemory,
+    parse_diagnostics,
+)
+from pedro_agentware.memory.confidence import (
+    build_inference_request,
+    claim_node_id,
+    merge_confidence,
+)
+from pedro_agentware.memory.infer import infer
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TBOX_PATHS = [
+    str(REPO_ROOT / "ontologies/education/TBOX_LEARNING_SOFTWARE.ttl"),
+    str(REPO_ROOT / "ontologies/social/twitch_topics.ttl"),
+]
+
+SOURCES = {
+    "src-pprof-talk": "Talk transcript: bounded worker pools cap goroutine counts under load.",
+    "src-go-blog-pipelines": "Go blog: pipelines and cancellation; worker pools bound concurrency.",
+    "src-team-runbook": "Team runbook: use worker pools; goroutine leaks page the on-call.",
+    "src-hn-comment": "Comment: goroutine leaks are harmless, the runtime cleans them up eventually.",
+}
+
+
+def page_markdown(claims: list[dict[str, Any]]) -> str:
+    """Render the worker-pools page with the given claims block."""
+    lines = [
+        "---",
+        "id: go-worker-pools",
+        "type: sw:Skill",
+        'labels: ["Worker Pools"]',
+        "topics: [twitch:Go]",
+        "claims:",
+    ]
+    for c in claims:
+        entry = {k: v for k, v in c.items() if k not in ("page",) and v not in (None, [], False)}
+        entry.setdefault("confidence", c.get("confidence"))
+        lines.append("  - " + json.dumps(entry))
+    lines += [
+        "sources: [src-pprof-talk, src-go-blog-pipelines, src-team-runbook]",
+        "---",
+        "",
+        "Worker pools bound concurrency. They build on [[goroutines]].",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+INITIAL_CLAIMS: list[dict[str, Any]] = [
+    {
+        "id": "c1",
+        "text": "Bounded worker pools prevent goroutine leaks under load",
+        "sources": ["src-pprof-talk", "src-team-runbook"],
+        "confidence": None,
+    },
+    {
+        "id": "c2",
+        "text": "Worker pools bound concurrency",
+        "sources": ["src-go-blog-pipelines"],
+        "supports": ["c1"],
+        "confidence": None,
+    },
+    {
+        "id": "c3",
+        "text": "Goroutine leaks are harmless in practice",
+        "sources": ["src-hn-comment"],
+        "contradicts": ["c1"],
+        "confidence": None,
+    },
+]
+
+
+def run(root: str) -> dict[str, Any]:
+    """Execute the dogfood scenario; returns a report of what happened."""
+    deny_log: list[dict[str, str]] = []
+    with WikiMemory(
+        user_id="soypete", root=root, tbox_paths=TBOX_PATHS, session_id="dogfood"
+    ) as memory:
+        tools = {t.__name__: t for t in LangGraphMemoryTools(memory).tools()}
+
+        # 1. Ingest the three overlapping sources (enforced path).
+        for source_id in list(SOURCES)[:3]:
+            out = tools["memory_ingest"](source_id=source_id, text=SOURCES[source_id])
+            assert out.startswith("ingested"), out
+
+        # 2. First write attempt tags the page with twitch:Golang — a label,
+        #    not a concept. The ontology denies it with nearest-term
+        #    diagnostics; the agent corrects and retries.
+        wrong = page_markdown(INITIAL_CLAIMS[:2]).replace(
+            "topics: [twitch:Go]", "topics: [twitch:Golang]"
+        )
+        out = tools["memory_write_page"](content=wrong)
+        assert out.startswith("DENIED:"), "expected the ontology to deny twitch:Golang"
+        violations = parse_diagnostics(out)
+        nearest = violations[0].nearest[0].rsplit("/", 1)[-1]
+        deny_log.append(
+            {"attempt": "twitch:Golang", "constraint": violations[0].constraint,
+             "corrected_to": f"twitch:{nearest}"}
+        )
+        corrected = wrong.replace("twitch:Golang", f"twitch:{nearest}")
+        out = tools["memory_write_page"](content=corrected)
+        assert out == "wrote go-worker-pools", out
+
+        # 3. Fourth source contradicts c1; record the contradicting claim.
+        out = tools["memory_ingest"](source_id="src-hn-comment", text=SOURCES["src-hn-comment"])
+        assert out.startswith("ingested"), out
+        out = tools["memory_write_page"](content=page_markdown(INITIAL_CLAIMS))
+        assert out == "wrote go-worker-pools", out
+
+        # 4. Inference over the vault's claims; write confidence back.
+        claims = memory.get_claims()[0]
+        baseline = infer(
+            build_inference_request(
+                [c for c in claims if c["id"] != "c3"],
+                reliability={"src-pprof-talk": 0.9, "src-go-blog-pipelines": 0.9,
+                             "src-team-runbook": 0.9},
+            )
+        )
+        response = infer(
+            build_inference_request(
+                claims,
+                reliability={"src-pprof-talk": 0.9, "src-go-blog-pipelines": 0.9,
+                             "src-team-runbook": 0.9},
+            )
+        )
+        merged = merge_confidence(claims, response)
+        out = tools["memory_write_page"](content=page_markdown(merged))
+        assert out == "wrote go-worker-pools", out
+        final_claims = memory.get_claims("go-worker-pools")[0]
+
+    c1 = claim_node_id("go-worker-pools", "c1")
+    c3 = claim_node_id("go-worker-pools", "c3")
+    return {
+        "deny_log": deny_log,
+        "baseline_c1": baseline["marginals"][c1],
+        "final_c1": response["marginals"][c1],
+        "final_c3": response["marginals"][c3],
+        "contested_c1": response["contested"][c1],
+        "contested_c3": response["contested"][c3],
+        "written_back": {
+            c["id"]: {"confidence": c["confidence"], "contested": c.get("contested", False)}
+            for c in final_claims
+        },
+        "method": response["method"],
+    }
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        report = run(str(Path(tmp) / "memory"))
+    print(json.dumps(report, indent=2))
+    drop = report["baseline_c1"] - report["final_c1"]
+    print(f"\nc1 confidence dropped {report['baseline_c1']:.3f} -> "
+          f"{report['final_c1']:.3f} (Δ {drop:.3f}); contested={report['contested_c1']}")
+    print(f"deny→retry cycles: {len(report['deny_log'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+inference = [
+    "pgmpy>=0.1.26",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/python/src/pedro_agentware/memory/__init__.py
+++ b/python/src/pedro_agentware/memory/__init__.py
@@ -1,0 +1,25 @@
+"""Wiki memory - client for the Go core's ontology-constrained wiki memory.
+
+WikiMemory spawns the Go MCP stdio server (``memctl serve``) scoped to one
+user and exposes the enforced memory tools. It implements the SDK's
+ToolExecutor protocol, so it composes into MiddlewareImpl like any other
+executor.
+"""
+
+from .client import (
+    MEMORY_TOOLS,
+    DiagnosticViolation,
+    MemoryServerError,
+    WikiMemory,
+    parse_diagnostics,
+)
+from .langgraph import LangGraphMemoryTools
+
+__all__ = [
+    "WikiMemory",
+    "MemoryServerError",
+    "DiagnosticViolation",
+    "parse_diagnostics",
+    "MEMORY_TOOLS",
+    "LangGraphMemoryTools",
+]

--- a/python/src/pedro_agentware/memory/client.py
+++ b/python/src/pedro_agentware/memory/client.py
@@ -1,0 +1,195 @@
+"""MCP stdio client for the Go wiki-memory core."""
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+MEMORY_TOOLS = [
+    "memory_ingest",
+    "memory_write_page",
+    "memory_query",
+    "memory_get_claims",
+    "memory_lint",
+]
+
+DIAGNOSTICS_MARKER = "diagnostics: "
+
+
+class MemoryServerError(RuntimeError):
+    """Transport or JSON-RPC failure talking to the memory server."""
+
+
+@dataclass
+class DiagnosticViolation:
+    """Structured ontology violation from a DENY decision."""
+
+    constraint: str
+    term: str
+    message: str
+    nearest: list[str] = field(default_factory=list)
+
+
+def parse_diagnostics(error_text: str) -> list[DiagnosticViolation]:
+    """Extract structured violations from a deny reason, if present."""
+    idx = error_text.find(DIAGNOSTICS_MARKER)
+    if idx < 0:
+        return []
+    payload = error_text[idx + len(DIAGNOSTICS_MARKER) :]
+    try:
+        raw = json.loads(payload)
+    except json.JSONDecodeError:
+        return []
+    return [
+        DiagnosticViolation(
+            constraint=v.get("constraint", ""),
+            term=v.get("term", ""),
+            message=v.get("message", ""),
+            nearest=v.get("nearest", []) or [],
+        )
+        for v in raw
+    ]
+
+
+class WikiMemory:
+    """Composable wiki-memory enablement for one user.
+
+    Spawns ``memctl serve`` (the Go core) as a subprocess speaking MCP over
+    stdio. The subprocess is scoped to ``user_id`` for its lifetime; the
+    server's policy tier denies any in-band attempt to change scope.
+
+    Implements the ToolExecutor protocol
+    (``execute(tool_name, args) -> (result, success, error)``), so it can be
+    passed to ``MiddlewareImpl`` directly::
+
+        memory = WikiMemory(user_id="alice", root="/var/memory",
+                            tbox_paths=[...])
+        mw = MiddlewareImpl(executor=memory).with_auditor(auditor)
+    """
+
+    def __init__(
+        self,
+        user_id: str,
+        root: str,
+        tbox_paths: list[str],
+        memctl_path: str | None = None,
+        session_id: str = "python-sdk",
+    ) -> None:
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not tbox_paths:
+            raise ValueError("tbox_paths is required (the T-box is a parameter)")
+        self.user_id = user_id
+        binary = memctl_path or os.environ.get("PEDRO_MEMCTL", "memctl")
+        cmd = [binary, "serve", "-root", root, "-user", user_id, "-session", session_id]
+        for path in tbox_paths:
+            cmd.extend(["-tbox", path])
+        try:
+            self._proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except OSError as exc:
+            raise MemoryServerError(f"failed to spawn {binary}: {exc}") from exc
+        self._next_id = 0
+        self._request("initialize", {})
+        self._notify("notifications/initialized")
+
+    # -- MCP transport -------------------------------------------------
+
+    def _send(self, message: dict[str, Any]) -> None:
+        proc = self._proc
+        if proc.stdin is None or proc.poll() is not None:
+            raise MemoryServerError(self._death_reason())
+        proc.stdin.write(json.dumps(message) + "\n")
+        proc.stdin.flush()
+
+    def _notify(self, method: str) -> None:
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        self._next_id += 1
+        self._send(
+            {"jsonrpc": "2.0", "id": self._next_id, "method": method, "params": params}
+        )
+        stdout = self._proc.stdout
+        if stdout is None:
+            raise MemoryServerError("server stdout closed")
+        line = stdout.readline()
+        if not line:
+            raise MemoryServerError(self._death_reason())
+        response: dict[str, Any] = json.loads(line)
+        if "error" in response and response["error"] is not None:
+            err = response["error"]
+            raise MemoryServerError(f"rpc {err.get('code')}: {err.get('message')}")
+        result: dict[str, Any] = response.get("result", {})
+        return result
+
+    def _death_reason(self) -> str:
+        stderr = ""
+        if self._proc.stderr is not None and self._proc.poll() is not None:
+            stderr = self._proc.stderr.read().strip()
+        return f"memory server exited (code={self._proc.poll()}): {stderr}"
+
+    # -- ToolExecutor protocol -----------------------------------------
+
+    def execute(self, tool_name: str, args: dict[str, Any]) -> tuple[Any, bool, str]:
+        """Execute a memory tool. Returns (output_text, success, error)."""
+        result = self._request("tools/call", {"name": tool_name, "arguments": args})
+        blocks = result.get("content", [])
+        text = "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+        if result.get("isError"):
+            return None, False, text
+        return text, True, ""
+
+    # -- Native API ----------------------------------------------------
+
+    def tools(self) -> list[dict[str, Any]]:
+        """List the memory tools served by the core."""
+        result = self._request("tools/list", {})
+        tools: list[dict[str, Any]] = result.get("tools", [])
+        return tools
+
+    def ingest(self, source_id: str, text: str) -> tuple[Any, bool, str]:
+        return self.execute("memory_ingest", {"source_id": source_id, "text": text})
+
+    def write_page(self, content: str) -> tuple[Any, bool, str]:
+        return self.execute("memory_write_page", {"content": content})
+
+    def query(self, question: str) -> tuple[Any, bool, str]:
+        output, ok, err = self.execute("memory_query", {"question": question})
+        return (json.loads(output) if ok and output else output), ok, err
+
+    def get_claims(self, page_id: str | None = None) -> tuple[Any, bool, str]:
+        args: dict[str, Any] = {}
+        if page_id:
+            args["page_id"] = page_id
+        output, ok, err = self.execute("memory_get_claims", args)
+        return (json.loads(output) if ok and output else output), ok, err
+
+    def lint(self) -> tuple[Any, bool, str]:
+        output, ok, err = self.execute("memory_lint", {})
+        return (json.loads(output) if ok and output else output), ok, err
+
+    # -- Lifecycle -----------------------------------------------------
+
+    def close(self) -> None:
+        """Terminate the memory server subprocess."""
+        if self._proc.poll() is None:
+            if self._proc.stdin is not None:
+                self._proc.stdin.close()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=5)
+
+    def __enter__(self) -> "WikiMemory":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()

--- a/python/src/pedro_agentware/memory/confidence.py
+++ b/python/src/pedro_agentware/memory/confidence.py
@@ -1,0 +1,88 @@
+"""Glue between vault claims and the Markov link network contract.
+
+``build_inference_request`` turns ``memory_get_claims`` output into the
+JSON contract (``go/memory/infer/schema.json``); ``merge_confidence``
+folds an inference response back into claim dicts so the agent can rewrite
+pages — through the enforced write path — with updated ``confidence`` and
+``contested`` values.
+"""
+
+from typing import Any
+
+
+def claim_node_id(page: str, claim_id: str) -> str:
+    """Global node id for a claim: '<page>#<claim-id>'."""
+    return f"{page}#{claim_id}"
+
+
+def _resolve_ref(page: str, ref: str) -> str:
+    return ref if "#" in ref else claim_node_id(page, ref)
+
+
+def build_inference_request(
+    claims: list[dict[str, Any]],
+    supersedes: list[tuple[str, str]] | None = None,
+    reliability: dict[str, float] | None = None,
+    weights: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Build the inference request for a vault's claims.
+
+    claims is ``memory_get_claims`` output. supersedes lists
+    (newer_source_id, superseded_source_id) pairs. reliability overrides
+    per-source priors.
+    """
+    reliability = reliability or {}
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, str]] = []
+    source_ids: set[str] = set()
+
+    for claim in claims:
+        node = claim_node_id(claim["page"], claim["id"])
+        nodes.append({"id": node, "kind": "claim"})
+        for source_id in claim.get("sources") or []:
+            source_ids.add(source_id)
+            edges.append({"type": "sourceOf", "source": source_id, "target": node})
+        for ref in claim.get("supports") or []:
+            edges.append(
+                {"type": "supports", "source": node, "target": _resolve_ref(claim["page"], ref)}
+            )
+        for ref in claim.get("contradicts") or []:
+            edges.append(
+                {
+                    "type": "contradicts",
+                    "source": node,
+                    "target": _resolve_ref(claim["page"], ref),
+                }
+            )
+
+    for newer, older in supersedes or []:
+        source_ids.update((newer, older))
+        edges.append({"type": "supersedes", "source": newer, "target": older})
+
+    for source_id in sorted(source_ids):
+        source_node: dict[str, Any] = {"id": source_id, "kind": "source"}
+        if source_id in reliability:
+            source_node["reliability"] = reliability[source_id]
+        nodes.append(source_node)
+
+    request: dict[str, Any] = {"nodes": nodes, "edges": edges}
+    if weights:
+        request["weights"] = weights
+    return request
+
+
+def merge_confidence(
+    claims: list[dict[str, Any]], response: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Return claim dicts with confidence/contested from an inference response."""
+    marginals = response.get("marginals", {})
+    contested = response.get("contested", {})
+    merged = []
+    for claim in claims:
+        node = claim_node_id(claim["page"], claim["id"])
+        updated = dict(claim)
+        if node in marginals:
+            updated["confidence"] = marginals[node]
+            updated["contested"] = bool(contested.get(node, False))
+        merged.append(updated)
+    return merged

--- a/python/src/pedro_agentware/memory/infer.py
+++ b/python/src/pedro_agentware/memory/infer.py
@@ -1,0 +1,208 @@
+"""Markov link network inference over wiki-memory claims.
+
+Implements the JSON contract in ``go/memory/infer/schema.json``: claim and
+source-reliability nodes with binary states, typed edges (supports,
+contradicts, sourceOf, supersedes) turned into pairwise potentials, and
+per-claim marginals as probabilities. Belief propagation first; Gibbs
+sampling fallback if it fails.
+
+Runnable as a subprocess (the Go core's transport)::
+
+    python -m pedro_agentware.memory.infer < request.json > response.json
+
+Requires the ``inference`` extra (pgmpy).
+"""
+
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_WEIGHTS = {
+    "supports": 0.8,
+    "contradicts": 0.9,
+    "sourceOf": 0.85,
+    "sourcePrior": 0.7,
+    "supersededPrior": 0.4,
+    "contestedThreshold": 0.6,
+}
+
+EDGE_TYPES = {"supports", "contradicts", "sourceOf", "supersedes"}
+
+
+class InferenceError(ValueError):
+    """Invalid inference request."""
+
+
+@dataclass
+class Network:
+    """Validated request: nodes, typed edges, effective weights."""
+
+    claims: list[str]
+    sources: list[str]
+    reliability: dict[str, float]
+    edges: list[tuple[str, str, str]]  # (type, source, target)
+    weights: dict[str, float]
+    contradicts_pairs: list[tuple[str, str]] = field(default_factory=list)
+
+
+def _build_network(request: dict[str, Any]) -> Network:
+    weights = {**DEFAULT_WEIGHTS, **(request.get("weights") or {})}
+    claims: list[str] = []
+    sources: list[str] = []
+    reliability: dict[str, float] = {}
+    seen: set[str] = set()
+    for node in request.get("nodes", []):
+        node_id, kind = node.get("id"), node.get("kind")
+        if not node_id or kind not in ("claim", "source"):
+            raise InferenceError(f"bad node: {node}")
+        if node_id in seen:
+            raise InferenceError(f"duplicate node id: {node_id}")
+        seen.add(node_id)
+        if kind == "claim":
+            claims.append(node_id)
+        else:
+            sources.append(node_id)
+            reliability[node_id] = float(node.get("reliability", weights["sourcePrior"]))
+    if not claims:
+        raise InferenceError("no claim nodes")
+
+    superseded: set[str] = set()
+    edges: list[tuple[str, str, str]] = []
+    contradicts_pairs: list[tuple[str, str]] = []
+    for edge in request.get("edges", []):
+        etype, src, dst = edge.get("type"), edge.get("source"), edge.get("target")
+        if etype not in EDGE_TYPES:
+            raise InferenceError(f"bad edge type: {etype}")
+        if src not in seen or dst not in seen:
+            raise InferenceError(f"edge references unknown node: {edge}")
+        if etype == "supersedes":
+            superseded.add(dst)
+            continue
+        edges.append((etype, src, dst))
+        if etype == "contradicts":
+            contradicts_pairs.append((src, dst))
+    for source_id in superseded:
+        if source_id in reliability and "reliability" not in _node_by_id(request, source_id):
+            reliability[source_id] = weights["supersededPrior"]
+    return Network(
+        claims=claims,
+        sources=sources,
+        reliability=reliability,
+        edges=edges,
+        weights=weights,
+        contradicts_pairs=contradicts_pairs,
+    )
+
+
+def _node_by_id(request: dict[str, Any], node_id: str) -> dict[str, Any]:
+    for node in request.get("nodes", []):
+        if node.get("id") == node_id:
+            return node
+    return {}
+
+
+def _build_model(net: Network) -> Any:
+    from pgmpy.factors.discrete import DiscreteFactor
+
+    try:  # pgmpy >= 1.0
+        from pgmpy.models import DiscreteMarkovNetwork as MarkovNetwork
+    except ImportError:  # pragma: no cover - older pgmpy
+        from pgmpy.models import MarkovNetwork
+
+    model = MarkovNetwork()
+    model.add_nodes_from(net.claims + net.sources)
+
+    def agreement(a: str, b: str, w: float) -> Any:
+        return DiscreteFactor([a, b], [2, 2], [w, 1 - w, 1 - w, w])
+
+    def disagreement(a: str, b: str, w: float) -> Any:
+        return DiscreteFactor([a, b], [2, 2], [1 - w, w, w, 1 - w])
+
+    connected = {n for _, src, dst in net.edges for n in (src, dst)}
+    factors = []
+    for source_id in net.sources:
+        if source_id not in connected:
+            # A source with no remaining edges (e.g. one that only
+            # supersedes) carries no information; keeping it disconnects
+            # the graph for belief propagation.
+            model.remove_node(source_id)
+            continue
+        r = net.reliability[source_id]
+        factors.append(DiscreteFactor([source_id], [2], [1 - r, r]))
+    for claim_id in net.claims:
+        # Weak uniform prior keeps isolated claims well-defined.
+        factors.append(DiscreteFactor([claim_id], [2], [0.5, 0.5]))
+    for etype, src, dst in net.edges:
+        if src == dst:
+            raise InferenceError(f"self edge on {src}")
+        model.add_edge(src, dst)
+        if etype == "supports":
+            factors.append(agreement(src, dst, net.weights["supports"]))
+        elif etype == "contradicts":
+            factors.append(disagreement(src, dst, net.weights["contradicts"]))
+        elif etype == "sourceOf":
+            factors.append(agreement(src, dst, net.weights["sourceOf"]))
+    model.add_factors(*factors)
+    return model
+
+
+def _marginals_bp(model: Any, claims: list[str]) -> dict[str, float]:
+    from pgmpy.inference import BeliefPropagation
+
+    bp = BeliefPropagation(model)
+    bp.calibrate()
+    out: dict[str, float] = {}
+    for claim_id in claims:
+        marginal = bp.query([claim_id], show_progress=False)
+        out[claim_id] = float(marginal.values[1])
+    return out
+
+
+def _marginals_gibbs(model: Any, claims: list[str], samples: int = 4000) -> dict[str, float]:
+    from pgmpy.sampling import GibbsSampling
+
+    gibbs = GibbsSampling(model)
+    frame = gibbs.sample(size=samples, seed=7)
+    return {claim_id: float(frame[claim_id].mean()) for claim_id in claims}
+
+
+def infer(request: dict[str, Any]) -> dict[str, Any]:
+    """Run inference per the JSON contract; returns the response object."""
+    net = _build_network(request)
+    model = _build_model(net)
+    try:
+        marginals = _marginals_bp(model, net.claims)
+        method = "belief_propagation"
+    except Exception:  # noqa: BLE001 - any BP failure falls back to sampling
+        marginals = _marginals_gibbs(model, net.claims)
+        method = "gibbs"
+
+    threshold = net.weights["contestedThreshold"]
+    contested = {claim_id: False for claim_id in net.claims}
+    for a, b in net.contradicts_pairs:
+        if a in contested and marginals.get(b, 0.0) > threshold:
+            contested[a] = True
+        if b in contested and marginals.get(a, 0.0) > threshold:
+            contested[b] = True
+    return {
+        "marginals": {k: round(v, 6) for k, v in marginals.items()},
+        "contested": contested,
+        "method": method,
+    }
+
+
+def main() -> int:
+    """Subprocess entry point: JSON request on stdin, response on stdout."""
+    try:
+        request = json.load(sys.stdin)
+        response = infer(request)
+    except Exception as exc:  # noqa: BLE001 - errors go on the wire
+        json.dump({"error": str(exc)}, sys.stdout)
+        return 1
+    json.dump(response, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/src/pedro_agentware/memory/langgraph.py
+++ b/python/src/pedro_agentware/memory/langgraph.py
@@ -1,0 +1,73 @@
+"""LangGraph integration: expose wiki-memory tools to a LangGraph agent.
+
+LangGraph accepts plain Python callables as tools (it introspects name,
+docstring, and signature). ``LangGraphMemoryTools`` builds one callable per
+memory tool bound to a WikiMemory client, so wrapping an agent is::
+
+    memory = WikiMemory(user_id="alice", root=..., tbox_paths=[...])
+    tools = LangGraphMemoryTools(memory).tools()
+    graph = create_react_agent(model, tools=[*agent_tools, *tools])
+
+Denied writes return the deny reason (including the structured diagnostics
+payload) as the tool output, so the agent can self-correct and retry.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from .client import WikiMemory
+
+
+class LangGraphMemoryTools:
+    """Builds LangGraph-compatible tool callables for a WikiMemory client."""
+
+    def __init__(self, memory: WikiMemory) -> None:
+        self._memory = memory
+
+    def tools(self) -> list[Callable[..., str]]:
+        """Return the memory tools as plain callables."""
+        memory = self._memory
+
+        def memory_ingest(source_id: str, text: str) -> str:
+            """Store a raw source document in the user's memory vault."""
+            return _render(memory.ingest(source_id, text))
+
+        def memory_write_page(content: str) -> str:
+            """Create or update an ontology-validated wiki page.
+
+            content must be full page markdown with YAML frontmatter per the
+            memory schema. On DENY the returned text includes structured
+            diagnostics — fix the page and retry.
+            """
+            return _render(memory.write_page(content))
+
+        def memory_query(question: str) -> str:
+            """Query the user's wiki memory."""
+            return _render(memory.query(question))
+
+        def memory_get_claims(page_id: str = "") -> str:
+            """List claims tracked in the user's vault, optionally per page."""
+            return _render(memory.get_claims(page_id or None))
+
+        def memory_lint() -> str:
+            """Report contract, ontology, and graph issues in the vault."""
+            return _render(memory.lint())
+
+        return [
+            memory_ingest,
+            memory_write_page,
+            memory_query,
+            memory_get_claims,
+            memory_lint,
+        ]
+
+
+def _render(result: tuple[Any, bool, str]) -> str:
+    output, ok, err = result
+    if not ok:
+        return f"DENIED: {err}"
+    if isinstance(output, str):
+        return output
+    import json
+
+    return json.dumps(output, indent=2)

--- a/python/tests/dogfood_test.py
+++ b/python/tests/dogfood_test.py
@@ -54,3 +54,7 @@ def test_dogfood_scenario(
     written = report["written_back"]
     assert written["c1"]["confidence"] == pytest.approx(report["final_c1"])
     assert written["c3"]["contested"] is True
+
+    # And the queries see the inferred state.
+    assert report["contested_query"] == ["c3"]
+    assert report["low_confidence_query"] == ["c3"]

--- a/python/tests/dogfood_test.py
+++ b/python/tests/dogfood_test.py
@@ -1,0 +1,56 @@
+"""End-to-end dogfood: enforced ingest → deny/retry → contradiction → inference."""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pgmpy", reason="install the 'inference' extra")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO_ROOT / "python" / "examples"
+sys.path.insert(0, str(EXAMPLES))
+
+from wiki_memory_dogfood import TBOX_PATHS, run  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def memctl(tmp_path_factory: pytest.TempPathFactory) -> str:
+    if shutil.which("go") is None:
+        pytest.skip("go toolchain unavailable")
+    if not Path(TBOX_PATHS[0]).exists():
+        pytest.skip("ontologies submodule missing (git submodule update --init)")
+    binary = tmp_path_factory.mktemp("bin") / "memctl"
+    subprocess.run(
+        ["go", "build", "-o", str(binary), "./cmd/memctl"],
+        cwd=REPO_ROOT / "go",
+        check=True,
+        capture_output=True,
+    )
+    return str(binary)
+
+
+def test_dogfood_scenario(
+    memctl: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PEDRO_MEMCTL", memctl)
+    report = run(str(tmp_path / "memory"))
+
+    # Deny→retry cycle happened and was driven by the diagnostics.
+    assert len(report["deny_log"]) == 1
+    assert report["deny_log"][0]["constraint"] == "unknown-concept"
+    assert report["deny_log"][0]["corrected_to"] == "twitch:Go"
+
+    # The contradicting 4th source lowers the earlier claim's confidence...
+    assert report["final_c1"] < report["baseline_c1"]
+    # ...and the contested flag sets on the contradiction (the weakly
+    # sourced opposing claim faces a confident counterpart).
+    assert report["contested_c3"] is True
+    assert report["final_c3"] < 0.5
+
+    # Confidence landed back in the vault through the enforced write path.
+    written = report["written_back"]
+    assert written["c1"]["confidence"] == pytest.approx(report["final_c1"])
+    assert written["c3"]["contested"] is True

--- a/python/tests/infer_test.py
+++ b/python/tests/infer_test.py
@@ -1,0 +1,142 @@
+"""Unit tests for the Markov link network inference engine (pgmpy)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pgmpy", reason="install the 'inference' extra")
+
+from pedro_agentware.memory.infer import InferenceError, infer  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "go/memory/infer/schema.json"
+
+
+def reliable(node_id: str) -> dict[str, Any]:
+    return {"id": node_id, "kind": "source", "reliability": 0.9}
+
+
+def claim(node_id: str) -> dict[str, Any]:
+    return {"id": node_id, "kind": "claim"}
+
+
+def edge(etype: str, source: str, target: str) -> dict[str, str]:
+    return {"type": etype, "source": source, "target": target}
+
+
+def assert_matches_response_contract(response: dict[str, Any]) -> None:
+    assert set(response) == {"marginals", "contested", "method"}
+    assert response["method"] in ("belief_propagation", "gibbs")
+    for value in response["marginals"].values():
+        assert 0.0 <= value <= 1.0
+    for value in response["contested"].values():
+        assert isinstance(value, bool)
+
+
+def test_mutually_supporting_claims_from_reliable_sources() -> None:
+    response = infer(
+        {
+            "nodes": [claim("c1"), claim("c2"), reliable("s1"), reliable("s2")],
+            "edges": [
+                edge("sourceOf", "s1", "c1"),
+                edge("sourceOf", "s2", "c2"),
+                edge("supports", "c1", "c2"),
+                edge("supports", "c2", "c1"),
+            ],
+        }
+    )
+    assert_matches_response_contract(response)
+    assert response["marginals"]["c1"] > 0.85
+    assert response["marginals"]["c2"] > 0.85
+    assert response["contested"] == {"c1": False, "c2": False}
+
+
+def test_contradicted_claim_from_superseded_source() -> None:
+    response = infer(
+        {
+            "nodes": [
+                claim("c1"),
+                claim("c2"),
+                {"id": "s1", "kind": "source"},
+                reliable("s2"),
+                {"id": "s3", "kind": "source"},
+            ],
+            "edges": [
+                edge("sourceOf", "s1", "c1"),
+                edge("sourceOf", "s2", "c2"),
+                edge("contradicts", "c2", "c1"),
+                edge("supersedes", "s3", "s1"),
+            ],
+        }
+    )
+    assert_matches_response_contract(response)
+    assert response["marginals"]["c1"] < 0.5
+    assert response["marginals"]["c2"] > 0.6
+    assert response["contested"]["c1"] is True
+    assert response["contested"]["c2"] is False
+
+
+def test_support_cycle_converges_or_falls_back() -> None:
+    response = infer(
+        {
+            "nodes": [claim("c1"), claim("c2"), claim("c3"), reliable("s1")],
+            "edges": [
+                edge("sourceOf", "s1", "c1"),
+                edge("supports", "c1", "c2"),
+                edge("supports", "c2", "c3"),
+                edge("supports", "c3", "c1"),
+            ],
+        }
+    )
+    assert_matches_response_contract(response)
+    # The cycle must not break inference: all three land on the same side,
+    # pulled up by c1's reliable source.
+    for claim_id in ("c1", "c2", "c3"):
+        assert response["marginals"][claim_id] > 0.5
+
+
+def test_invalid_requests_rejected() -> None:
+    with pytest.raises(InferenceError):
+        infer({"nodes": [], "edges": []})
+    with pytest.raises(InferenceError):
+        infer({"nodes": [claim("c1")], "edges": [edge("supports", "c1", "ghost")]})
+    with pytest.raises(InferenceError):
+        infer({"nodes": [claim("c1")], "edges": [edge("frobnicates", "c1", "c1")]})
+
+
+def test_subprocess_contract_roundtrip() -> None:
+    request = {
+        "nodes": [claim("c1"), reliable("s1")],
+        "edges": [edge("sourceOf", "s1", "c1")],
+    }
+    proc = subprocess.run(
+        [sys.executable, "-m", "pedro_agentware.memory.infer"],
+        input=json.dumps(request),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    response = json.loads(proc.stdout)
+    assert_matches_response_contract(response)
+    assert response["marginals"]["c1"] > 0.5
+
+    bad = subprocess.run(
+        [sys.executable, "-m", "pedro_agentware.memory.infer"],
+        input="{}",
+        capture_output=True,
+        text=True,
+    )
+    assert bad.returncode == 1
+    assert "error" in json.loads(bad.stdout)
+
+
+def test_schema_file_declares_the_contract() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text())
+    defs = schema["$defs"]
+    assert set(defs["response"]["properties"]) == {"marginals", "contested", "method"}
+    edge_types = defs["request"]["properties"]["edges"]["items"]["properties"]["type"]["enum"]
+    assert set(edge_types) == {"supports", "contradicts", "sourceOf", "supersedes"}

--- a/python/tests/memory_client_test.py
+++ b/python/tests/memory_client_test.py
@@ -1,0 +1,117 @@
+"""Tests for the WikiMemory MCP client against the real Go core."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pedro_agentware.memory import (
+    LangGraphMemoryTools,
+    WikiMemory,
+    parse_diagnostics,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TBOX_PATHS = [
+    str(REPO_ROOT / "ontologies/education/TBOX_LEARNING_SOFTWARE.ttl"),
+    str(REPO_ROOT / "ontologies/social/twitch_topics.ttl"),
+]
+
+VALID_PAGE = """---
+id: go-worker-pools
+type: sw:Skill
+labels: ["Worker Pools"]
+topics: [twitch:Go]
+claims:
+  - {id: c1, text: "Bounded pools prevent goroutine leaks", sources: [src-talk]}
+---
+Pools bound concurrency.
+"""
+
+
+@pytest.fixture(scope="session")
+def memctl(tmp_path_factory: pytest.TempPathFactory) -> str:
+    if shutil.which("go") is None:
+        pytest.skip("go toolchain unavailable")
+    if not Path(TBOX_PATHS[0]).exists():
+        pytest.skip("ontologies submodule missing (git submodule update --init)")
+    binary = tmp_path_factory.mktemp("bin") / "memctl"
+    subprocess.run(
+        ["go", "build", "-o", str(binary), "./cmd/memctl"],
+        cwd=REPO_ROOT / "go",
+        check=True,
+        capture_output=True,
+    )
+    return str(binary)
+
+
+@pytest.fixture()
+def vault_root(tmp_path: Path) -> str:
+    return str(tmp_path / "memory")
+
+
+def make_memory(memctl: str, root: str, user: str) -> WikiMemory:
+    return WikiMemory(
+        user_id=user, root=root, tbox_paths=TBOX_PATHS, memctl_path=memctl
+    )
+
+
+def test_tools_listed(memctl: str, vault_root: str) -> None:
+    with make_memory(memctl, vault_root, "alice") as memory:
+        names = {t["name"] for t in memory.tools()}
+    assert names == {
+        "memory_ingest",
+        "memory_write_page",
+        "memory_query",
+        "memory_get_claims",
+        "memory_lint",
+    }
+
+
+def test_write_query_claims_roundtrip(memctl: str, vault_root: str) -> None:
+    with make_memory(memctl, vault_root, "alice") as memory:
+        _, ok, err = memory.write_page(VALID_PAGE)
+        assert ok, err
+        hits, ok, err = memory.query("worker pools")
+        assert ok and any(h["id"] == "go-worker-pools" for h in hits)
+        claims, ok, err = memory.get_claims("go-worker-pools")
+        assert ok and claims[0]["text"].startswith("Bounded pools")
+        assert claims[0]["confidence"] is None
+
+
+def test_deny_carries_parseable_diagnostics(memctl: str, vault_root: str) -> None:
+    with make_memory(memctl, vault_root, "alice") as memory:
+        _, ok, err = memory.write_page("---\nid: bad-page\ntype: sw:Skil\n---\n")
+    assert not ok
+    violations = parse_diagnostics(err)
+    assert violations and violations[0].constraint == "unknown-class"
+    assert violations[0].nearest and violations[0].nearest[0].endswith("Skill")
+
+
+def test_user_isolation_across_clients(memctl: str, vault_root: str) -> None:
+    with make_memory(memctl, vault_root, "alice") as alice:
+        _, ok, err = alice.write_page(VALID_PAGE)
+        assert ok, err
+    with make_memory(memctl, vault_root, "bob") as bob:
+        hits, ok, _ = bob.query("worker pools")
+        assert ok and hits is not None and not hits
+        # In-band scope override is denied by the server's policy tier.
+        _, ok, err = bob.execute("memory_query", {"question": "x", "user_id": "alice"})
+        assert not ok and "denied by policy" in err
+
+
+def test_langgraph_tools_render_denials(memctl: str, vault_root: str) -> None:
+    with make_memory(memctl, vault_root, "alice") as memory:
+        tools = LangGraphMemoryTools(memory).tools()
+        by_name = {t.__name__: t for t in tools}
+        assert set(by_name) == {
+            "memory_ingest",
+            "memory_write_page",
+            "memory_query",
+            "memory_get_claims",
+            "memory_lint",
+        }
+        out = by_name["memory_write_page"](content="---\nid: p\ntype: nope\n---\n")
+        assert out.startswith("DENIED:")
+        assert by_name["memory_ingest"](source_id="src-a", text="notes") == "ingested src-a"

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,3 +6,4 @@ export * from "./llm/index.js";
 export * from "./llmcontext/index.js";
 export * from "./prompts/index.js";
 export * from "./toolformat/index.js";
+export * from "./memory/index.js";

--- a/typescript/src/memory/client.ts
+++ b/typescript/src/memory/client.ts
@@ -1,0 +1,214 @@
+/**
+ * Wiki memory - TypeScript client for the Go core's ontology-constrained
+ * wiki memory.
+ *
+ * WikiMemory spawns the Go MCP stdio server (`memctl serve`) scoped to one
+ * user. The subprocess owns enforcement: every call passes the Go
+ * middleware chain (declarative policy + ontology evaluator + audit), and
+ * in-band attempts to change user scope are denied. The API is async
+ * (subprocess I/O); inference stays in the Python SDK.
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createInterface, type Interface } from "node:readline";
+
+export const MEMORY_TOOLS = [
+  "memory_ingest",
+  "memory_write_page",
+  "memory_query",
+  "memory_get_claims",
+  "memory_lint",
+] as const;
+
+export const DIAGNOSTICS_MARKER = "diagnostics: ";
+
+/** Structured ontology violation from a DENY decision. */
+export interface DiagnosticViolation {
+  constraint: string;
+  term: string;
+  message: string;
+  nearest: string[];
+}
+
+/** Extract structured violations from a deny reason, if present. */
+export function parseDiagnostics(errorText: string): DiagnosticViolation[] {
+  const idx = errorText.indexOf(DIAGNOSTICS_MARKER);
+  if (idx < 0) return [];
+  try {
+    const raw = JSON.parse(errorText.slice(idx + DIAGNOSTICS_MARKER.length)) as Array<
+      Record<string, unknown>
+    >;
+    return raw.map((v) => ({
+      constraint: String(v.constraint ?? ""),
+      term: String(v.term ?? ""),
+      message: String(v.message ?? ""),
+      nearest: Array.isArray(v.nearest) ? v.nearest.map(String) : [],
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export class MemoryServerError extends Error {}
+
+export interface WikiMemoryOptions {
+  userId: string;
+  root: string;
+  tboxPaths: string[];
+  /** Path to the memctl binary; defaults to $PEDRO_MEMCTL or "memctl". */
+  memctlPath?: string;
+  sessionId?: string;
+}
+
+/** Result triple matching the SDK's executor convention. */
+export type ToolResult = [unknown, boolean, string];
+
+interface RpcResponse {
+  id?: number;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+export class WikiMemory {
+  readonly userId: string;
+  private proc: ChildProcessWithoutNullStreams;
+  private lines: Interface;
+  private pending: Array<{
+    resolve: (r: Record<string, unknown>) => void;
+    reject: (e: Error) => void;
+  }> = [];
+  private nextId = 0;
+  private ready: Promise<void>;
+
+  constructor(options: WikiMemoryOptions) {
+    if (!options.userId) throw new MemoryServerError("userId is required");
+    if (!options.tboxPaths.length) {
+      throw new MemoryServerError("tboxPaths is required (the T-box is a parameter)");
+    }
+    const binary =
+      options.memctlPath ?? process.env.PEDRO_MEMCTL ?? "memctl";
+    const args = [
+      "serve",
+      "-root", options.root,
+      "-user", options.userId,
+      "-session", options.sessionId ?? "typescript-sdk",
+    ];
+    for (const path of options.tboxPaths) args.push("-tbox", path);
+    this.userId = options.userId;
+    this.proc = spawn(binary, args, { stdio: ["pipe", "pipe", "pipe"] });
+    this.proc.on("error", (err) => this.failAll(new MemoryServerError(err.message)));
+    this.proc.on("exit", (code) =>
+      this.failAll(new MemoryServerError(`memory server exited (code=${code})`))
+    );
+    this.lines = createInterface({ input: this.proc.stdout });
+    this.lines.on("line", (line) => this.onLine(line));
+    this.ready = this.request("initialize", {}).then(() => {
+      this.notify("notifications/initialized");
+    });
+  }
+
+  private onLine(line: string): void {
+    if (!line.trim()) return;
+    const next = this.pending.shift();
+    if (!next) return;
+    let response: RpcResponse;
+    try {
+      response = JSON.parse(line) as RpcResponse;
+    } catch (err) {
+      next.reject(new MemoryServerError(`bad response: ${String(err)}`));
+      return;
+    }
+    if (response.error) {
+      next.reject(
+        new MemoryServerError(`rpc ${response.error.code}: ${response.error.message}`)
+      );
+      return;
+    }
+    next.resolve(response.result ?? {});
+  }
+
+  private failAll(err: Error): void {
+    const waiting = this.pending;
+    this.pending = [];
+    for (const p of waiting) p.reject(err);
+  }
+
+  private notify(method: string): void {
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", method }) + "\n");
+  }
+
+  private request(
+    method: string,
+    params: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    this.nextId += 1;
+    const message = { jsonrpc: "2.0", id: this.nextId, method, params };
+    return new Promise((resolve, reject) => {
+      this.pending.push({ resolve, reject });
+      this.proc.stdin.write(JSON.stringify(message) + "\n");
+    });
+  }
+
+  /** Execute a memory tool. Resolves to [outputText, success, error]. */
+  async execute(
+    toolName: string,
+    args: Record<string, unknown>
+  ): Promise<ToolResult> {
+    await this.ready;
+    const result = await this.request("tools/call", {
+      name: toolName,
+      arguments: args,
+    });
+    const blocks = (result.content ?? []) as Array<{ type: string; text?: string }>;
+    const text = blocks
+      .filter((b) => b.type === "text")
+      .map((b) => b.text ?? "")
+      .join("");
+    if (result.isError) return [null, false, text];
+    return [text, true, ""];
+  }
+
+  /** List the memory tools served by the core. */
+  async tools(): Promise<Array<{ name: string; description: string }>> {
+    await this.ready;
+    const result = await this.request("tools/list", {});
+    return (result.tools ?? []) as Array<{ name: string; description: string }>;
+  }
+
+  async ingest(sourceId: string, text: string): Promise<ToolResult> {
+    return this.execute("memory_ingest", { source_id: sourceId, text });
+  }
+
+  async writePage(content: string): Promise<ToolResult> {
+    return this.execute("memory_write_page", { content });
+  }
+
+  async query(question: string): Promise<ToolResult> {
+    return this.parsed(await this.execute("memory_query", { question }));
+  }
+
+  async getClaims(pageId?: string): Promise<ToolResult> {
+    const args: Record<string, unknown> = {};
+    if (pageId) args.page_id = pageId;
+    return this.parsed(await this.execute("memory_get_claims", args));
+  }
+
+  async lint(): Promise<ToolResult> {
+    return this.parsed(await this.execute("memory_lint", {}));
+  }
+
+  private parsed([output, ok, err]: ToolResult): ToolResult {
+    if (!ok || typeof output !== "string" || output === "") return [output, ok, err];
+    try {
+      return [JSON.parse(output), ok, err];
+    } catch {
+      return [output, ok, err];
+    }
+  }
+
+  /** Terminate the memory server subprocess. */
+  close(): void {
+    this.proc.stdin.end();
+    this.proc.kill();
+  }
+}

--- a/typescript/src/memory/index.ts
+++ b/typescript/src/memory/index.ts
@@ -1,0 +1,10 @@
+export {
+  DIAGNOSTICS_MARKER,
+  MEMORY_TOOLS,
+  MemoryServerError,
+  WikiMemory,
+  parseDiagnostics,
+} from "./client.js";
+export type { DiagnosticViolation, ToolResult, WikiMemoryOptions } from "./client.js";
+export { memoryTools } from "./tools.js";
+export type { MemoryTool } from "./tools.js";

--- a/typescript/src/memory/tools.ts
+++ b/typescript/src/memory/tools.ts
@@ -1,0 +1,71 @@
+/**
+ * Framework integration: expose wiki-memory tools in the Vercel AI SDK's
+ * tool shape ({ description, parameters, execute }).
+ *
+ * The returned record plugs directly into `generateText`/`streamText`:
+ *
+ *   const memory = new WikiMemory({ userId: "alice", root, tboxPaths });
+ *   const result = await generateText({ model, tools: memoryTools(memory), ... });
+ *
+ * Parameters are zod schemas (zod is already an SDK dependency). Denied
+ * writes resolve to "DENIED: ..." including the structured diagnostics
+ * payload, so the calling agent can self-correct and retry.
+ */
+
+import { z } from "zod";
+
+import type { ToolResult, WikiMemory } from "./client.js";
+
+export interface MemoryTool {
+  description: string;
+  parameters: z.ZodTypeAny;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+function render([output, ok, err]: ToolResult): string {
+  if (!ok) return `DENIED: ${err}`;
+  if (typeof output === "string") return output;
+  return JSON.stringify(output, null, 2);
+}
+
+export function memoryTools(memory: WikiMemory): Record<string, MemoryTool> {
+  return {
+    memory_ingest: {
+      description: "Store a raw source document in the user's memory vault.",
+      parameters: z.object({
+        source_id: z.string().describe("kebab-case source id, e.g. src-go-blog"),
+        text: z.string().describe("verbatim source text"),
+      }),
+      execute: async (args) =>
+        render(await memory.ingest(String(args.source_id), String(args.text))),
+    },
+    memory_write_page: {
+      description:
+        "Create or update an ontology-validated wiki page. content is full " +
+        "page markdown with YAML frontmatter per the memory schema; on DENY " +
+        "the response includes structured diagnostics - fix and retry.",
+      parameters: z.object({
+        content: z.string().describe("full page markdown including frontmatter"),
+      }),
+      execute: async (args) => render(await memory.writePage(String(args.content))),
+    },
+    memory_query: {
+      description: "Query the user's wiki memory.",
+      parameters: z.object({ question: z.string() }),
+      execute: async (args) => render(await memory.query(String(args.question))),
+    },
+    memory_get_claims: {
+      description: "List claims tracked in the user's vault, optionally per page.",
+      parameters: z.object({ page_id: z.string().optional() }),
+      execute: async (args) =>
+        render(
+          await memory.getClaims(args.page_id ? String(args.page_id) : undefined)
+        ),
+    },
+    memory_lint: {
+      description: "Report contract, ontology, and graph issues in the vault.",
+      parameters: z.object({}),
+      execute: async () => render(await memory.lint()),
+    },
+  };
+}

--- a/typescript/tests/memory-client.test.ts
+++ b/typescript/tests/memory-client.test.ts
@@ -1,0 +1,171 @@
+/**
+ * WikiMemory client tests against the real Go core, including the
+ * cross-SDK check: a page written via the Python SDK is readable through
+ * the TypeScript SDK for the same user and invisible to another user.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { WikiMemory, memoryTools, parseDiagnostics } from "../src/memory/index.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const TBOX_PATHS = [
+  join(REPO_ROOT, "ontologies/education/TBOX_LEARNING_SOFTWARE.ttl"),
+  join(REPO_ROOT, "ontologies/social/twitch_topics.ttl"),
+];
+
+const VALID_PAGE = `---
+id: go-worker-pools
+type: sw:Skill
+labels: ["Worker Pools"]
+topics: [twitch:Go]
+claims:
+  - {id: c1, text: "Bounded pools prevent goroutine leaks", sources: [src-talk]}
+---
+Pools bound concurrency.
+`;
+
+let memctl = "";
+let available = false;
+
+function tryExec(file: string, args: string[], options: object = {}): boolean {
+  try {
+    execFileSync(file, args, { stdio: "pipe", ...options });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+beforeAll(() => {
+  if (!existsSync(TBOX_PATHS[0])) return;
+  memctl = join(mkdtempSync(join(tmpdir(), "memctl-")), "memctl");
+  available = tryExec("go", ["build", "-o", memctl, "./cmd/memctl"], {
+    cwd: join(REPO_ROOT, "go"),
+  });
+});
+
+function newMemory(root: string, userId: string): WikiMemory {
+  return new WikiMemory({ userId, root, tboxPaths: TBOX_PATHS, memctlPath: memctl });
+}
+
+function freshRoot(): string {
+  return join(mkdtempSync(join(tmpdir(), "vault-")), "memory");
+}
+
+function skippable(name: string, fn: () => Promise<void>): void {
+  test(name, async () => {
+    if (!available) {
+      console.warn(`skipping ${name}: go toolchain or ontologies submodule missing`);
+      return;
+    }
+    await fn();
+  }, 30000);
+}
+
+skippable("lists the five memory tools", async () => {
+  const memory = newMemory(freshRoot(), "alice");
+  try {
+    const names = (await memory.tools()).map((t) => t.name).sort();
+    expect(names).toEqual([
+      "memory_get_claims",
+      "memory_ingest",
+      "memory_lint",
+      "memory_query",
+      "memory_write_page",
+    ]);
+  } finally {
+    memory.close();
+  }
+});
+
+skippable("write, query, and claims round-trip", async () => {
+  const memory = newMemory(freshRoot(), "alice");
+  try {
+    const [, ok, err] = await memory.writePage(VALID_PAGE);
+    expect(err).toBe("");
+    expect(ok).toBe(true);
+    const [hits, qok] = await memory.query("worker pools");
+    expect(qok).toBe(true);
+    expect((hits as Array<{ id: string }>).map((h) => h.id)).toContain("go-worker-pools");
+    const [claims, cok] = await memory.getClaims("go-worker-pools");
+    expect(cok).toBe(true);
+    expect((claims as Array<{ text: string; confidence: unknown }>)[0].confidence).toBeNull();
+  } finally {
+    memory.close();
+  }
+});
+
+skippable("denies carry parseable diagnostics", async () => {
+  const memory = newMemory(freshRoot(), "alice");
+  try {
+    const [, ok, err] = await memory.writePage("---\nid: bad-page\ntype: sw:Skil\n---\n");
+    expect(ok).toBe(false);
+    const violations = parseDiagnostics(err);
+    expect(violations[0].constraint).toBe("unknown-class");
+    expect(violations[0].nearest[0]).toMatch(/Skill$/);
+  } finally {
+    memory.close();
+  }
+});
+
+skippable("vercel-ai-shaped tools render denials for self-correction", async () => {
+  const memory = newMemory(freshRoot(), "alice");
+  try {
+    const tools = memoryTools(memory);
+    expect(Object.keys(tools).sort()).toEqual([
+      "memory_get_claims",
+      "memory_ingest",
+      "memory_lint",
+      "memory_query",
+      "memory_write_page",
+    ]);
+    const denied = await tools.memory_write_page.execute({
+      content: "---\nid: p\ntype: nope\n---\n",
+    });
+    expect(denied.startsWith("DENIED:")).toBe(true);
+    const okOut = await tools.memory_ingest.execute({ source_id: "src-a", text: "notes" });
+    expect(okOut).toBe("ingested src-a");
+  } finally {
+    memory.close();
+  }
+});
+
+skippable("cross-SDK: python-written page is visible to TS for the same user only", async () => {
+  const root = freshRoot();
+  // Write through the Python SDK (its own memctl subprocess, same vault root).
+  const script = [
+    "import sys",
+    `sys.path.insert(0, ${JSON.stringify(join(REPO_ROOT, "python/src"))})`,
+    "from pedro_agentware.memory import WikiMemory",
+    `memory = WikiMemory(user_id="alice", root=${JSON.stringify(root)},`,
+    `    tbox_paths=${JSON.stringify(TBOX_PATHS)}, memctl_path=${JSON.stringify(memctl)})`,
+    `_, ok, err = memory.write_page(${JSON.stringify(VALID_PAGE)})`,
+    "memory.close()",
+    "assert ok, err",
+  ].join("\n");
+  execFileSync("python3", ["-c", script], { stdio: "pipe" });
+
+  const alice = newMemory(root, "alice");
+  const bob = newMemory(root, "bob");
+  try {
+    const [hits, ok] = await alice.query("worker pools");
+    expect(ok).toBe(true);
+    expect((hits as Array<{ id: string }>).map((h) => h.id)).toContain("go-worker-pools");
+
+    const [bobHits, bobOk] = await bob.query("worker pools");
+    expect(bobOk).toBe(true);
+    expect(bobHits).toEqual([]);
+
+    const [bobClaims, claimsOk] = await bob.getClaims();
+    expect(claimsOk).toBe(true);
+    expect(bobClaims).toEqual([]);
+  } finally {
+    alice.close();
+    bob.close();
+  }
+});


### PR DESCRIPTION
## Summary

Adds **wiki memory** as a composable agentware capability: an LLM-maintained, ontology-constrained markdown wiki scoped per user, enforced through the existing middleware chain, exposed over MCP, with a Markov link network for claim confidence. Closes the v1 scope tracked in `PROGRESS.md`; v2 follow-ups are #90.

### Go core
- `go/memory`: per-user `Vault` (path-boundary containment), `page` parser (typed wikilinks, claim supports/contradicts refs, A-box as N-Triples), `ontology` validation package (T-box via `soypete/ontology-go`, domain/range, SKOS cycle + consistency, nearest-term diagnostics) with two consumers — the `OntologyEvaluator` and `memctl lint`.
- `OntologyEvaluator` implements `middleware.PolicyEvaluator`: declarative tier from embedded `policy.yaml` (deny-by-default, scope/anonymous denies, per-user+tool rate limits) + semantic tier on writes (T-box + vault-graph checks; cycle-introducing writes denied). DENY reasons carry a JSON diagnostics payload agents parse to self-correct.
- `memory.Enable(Config)` wires `NewMiddleware(exec).WithPolicy(...).WithAuditor(...)` and registers the five tools (`memory_ingest`, `memory_write_page`, `memory_query`, `memory_get_claims`, `memory_lint`).
- `go/mcp` + `memctl serve`: minimal MCP stdio server (JSON-RPC 2.0), one process per principal.
- `memory_query` competency questions (transitive prerequisites, builds-toward, role learning path, contested / low-confidence claims); `memory_lint` hygiene checks (orphans, pageless targets, stale pages, missing typed links).

### Python SDK
- `pedro_agentware.memory`: `WikiMemory` MCP client (implements the `ToolExecutor` protocol, composes into `MiddlewareImpl`), `LangGraphMemoryTools`, `parse_diagnostics`.
- `memory.infer` (pgmpy, `inference` extra): Markov link network per `go/memory/infer/schema.json` — BP with Gibbs fallback, contested flags. `memory.confidence` builds requests from vault claims and merges marginals back.
- Dogfood example + test: 3 overlapping sources, a deny→retry self-correction from diagnostics, a contradicting 4th source (claim 0.962→0.941; contrarian claim contested at 0.211), confidence written back through the enforced path, queries reflect the inferred state.

### TypeScript SDK
- `typescript/src/memory`: async `WikiMemory` MCP client, Vercel-AI-SDK-shaped `memoryTools()` (zod), cross-SDK test (Python-written page visible to TS for the same user, invisible to another).

### Isolation (load-bearing)
User scope comes only from `CallerContext`; in-band `user_id` args are denied by policy AND every filesystem path is re-checked against the caller's vault (tested in Go, Python, and TS).

### Upstream
The thesaurus fixture gate caught an inverted direction check in ontology-go's inconsistent-hierarchy validation — fixed in Soypete/ontology-go#18 (merged); `go.mod` tracks upstream main.

## Test plan
- `cd go && go vet ./... && go test ./...` (memory, ontology, page, mcp + existing suites)
- `cd python && pytest` with `[dev,inference]` extras (119 tests + dogfood E2E)
- `cd typescript && npm test` (131 tests incl. cross-SDK isolation)
- New `.github/workflows/memory-e2e.yml` runs the full fresh-clone → enable → ingest → infer → query chain in CI (needs `submodules: true`, which it sets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)